### PR TITLE
Fix ruff implicit optional errors

### DIFF
--- a/bzfs_main/bzfs.py
+++ b/bzfs_main/bzfs.py
@@ -6488,7 +6488,10 @@ def isotime_from_unixtime(unixtime_in_seconds: int) -> str:
     return dt.isoformat(sep="_", timespec="seconds")
 
 
-def current_datetime(tz_spec: str = None, now_fn: Callable[[Optional[tzinfo]], datetime] = None) -> datetime:
+def current_datetime(
+    tz_spec: Optional[str] = None,
+    now_fn: Optional[Callable[[Optional[tzinfo]], datetime]] = None,
+) -> datetime:
     """Returns a datetime that is the current time in the given timezone, or in the local timezone if tz_spec is absent."""
     now_fn = now_fn or datetime.now
     return now_fn(get_timezone(tz_spec))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ select = ["E", "F", "A", "B"]  # Or use ["ALL"] if you want every check enabled
 [tool.mypy]
 modules = ["bzfs_main"]
 python_version = "3.8"
-no_implicit_optional = false
 disable_error_code = [
   "assignment",
   "attr-defined",


### PR DESCRIPTION
## Summary
- remove deprecated `no_implicit_optional` mypy setting
- add explicit Optional annotations in `current_datetime`

## Testing
- `pre-commit run --all-files`
- `bzfs_test_mode=unit ./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_684283aca364832b80c58a2e9c8ae084