### PR TITLE
Remove mypy ignores and fix return handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,9 +120,6 @@ disable_error_code = [
   "no-redef",
   "type-var",
   "str-bytes-safe",
-  "func-returns-value",
-  "return",
-  "exit-return",
   "index",
   "call-arg",
 ]


### PR DESCRIPTION
## Summary
- enforce mypy return checks by dropping `func-returns-value`, `return` and `exit-return`
- clean up logging calls so they are no longer used in boolean contexts
- ensure `check_zfs_dataset_busy` returns a bool on all code paths
- annotate `_XFinally.__exit__` correctly

## Testing
- `pre-commit run --all-files`
- `bzfs_test_mode=unit ./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843bfa7fce4832b861d85c9c30a51e6