### PR TITLE
Improve typing coverage

### DIFF
--- a/.github-workflow-scripts/generate_badges.py
+++ b/.github-workflow-scripts/generate_badges.py
@@ -20,7 +20,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 ROOT_DIR = "badges"
 
@@ -73,10 +73,10 @@ def merge_versions(input_dir: str, natsort: bool = False) -> str:
 
 def sort_versions(version_list: List[str]) -> List[str]:
 
-    def is_valid_version(version):  # is in the form x.y.z ?
+    def is_valid_version(version: str) -> Optional[re.Match[str]]:  # is in the form x.y.z ?
         return re.match(r"^\d+(\.\d+){0,2}$", version)
 
-    def version_key(version):  # Split version into components and convert to integers
+    def version_key(version: str) -> List[int]:  # Split version into components and convert to integers
         return [int(part) for part in version.split(".")]
 
     valid_versions = [v for v in version_list if is_valid_version(v)]
@@ -84,7 +84,7 @@ def sort_versions(version_list: List[str]) -> List[str]:
     return sorted(valid_versions, key=version_key) + sorted(invalid_versions)
 
 
-def generate_badge(left_txt: str, right_txt, color: str) -> None:
+def generate_badge(left_txt: str, right_txt: str, color: str) -> None:
     from genbadge import Badge
 
     badge = Badge(left_txt=left_txt, right_txt=right_txt, color=color)

--- a/bash_completion_d/shell-completion-generator.py
+++ b/bash_completion_d/shell-completion-generator.py
@@ -23,7 +23,7 @@ or     python3 -m bash_completion_d.shell-completion-generator > ~/.bash_complet
 import argparse
 import importlib
 from pathlib import Path
-from typing import Set, Dict, List
+from typing import Dict, List, Set, Tuple
 
 programs = ("bzfs", "bzfs_jobrunner")
 
@@ -37,7 +37,7 @@ def version_line() -> str:
     raise RuntimeError("Version not found in bzfs argument parser.")
 
 
-def harvest(module: str):
+def harvest(module: str) -> Tuple[str, Set[str], Dict[str, str]]:
     """Returns (safe_name, flag_set, value_tokens_map) for a program based on its argument_parser() specs."""
     parser = importlib.import_module("bzfs_main." + module).argument_parser()
     safe = module.replace("-", "_")

--- a/bzfs_docs/update_readme.py
+++ b/bzfs_docs/update_readme.py
@@ -25,7 +25,7 @@ from bzfs_main import bzfs_jobrunner
 from bzfs_main.bzfs import find_match
 
 
-def main():
+def main() -> None:
     """
     Run this script to update README.md from the help info contained in bzfs.py.
     Example usage: cd ~/repos/bzfs; python3 -m bzfs_docs.update_readme bzfs_main/bzfs.py README.md
@@ -133,12 +133,12 @@ def main():
         raises=f"{end_help_overview_tag} not found in {readme_file}",
     )
     os.environ["COLUMNS"] = "72"
-    help_msg = (
+    help_msg_str = (
         bzfs.argument_parser().format_usage()
         if "_jobrunner" not in bzfs_module
         else bzfs_jobrunner.argument_parser().format_usage()
     )
-    help_msg = ["```\n"] + help_msg.splitlines(keepends=True) + ["```\n"]
+    help_msg = ["```\n"] + help_msg_str.splitlines(keepends=True) + ["```\n"]
     readme = readme[: begin_help_overview_idx + 1] + help_msg + readme[end_help_overview_idx:]
 
     # Step 6: Replace Usage Details Section

--- a/bzfs_main/bzfs.py
+++ b/bzfs_main/bzfs.py
@@ -6638,7 +6638,7 @@ def get_timezone(tz_spec: Optional[str] = None) -> Optional[tzinfo]:
             offset = -offset if sign == "-" else offset
             tz = timezone(timedelta(minutes=offset))
         elif "/" in tz_spec and sys.version_info >= (3, 9):
-            from zoneinfo import ZoneInfo  # type: ignore[import-not-found]
+            from zoneinfo import ZoneInfo
 
             tz = ZoneInfo(tz_spec)  # Standard IANA timezone. Example: "Europe/Vienna"
         else:

--- a/bzfs_main/bzfs.py
+++ b/bzfs_main/bzfs.py
@@ -6638,7 +6638,7 @@ def get_timezone(tz_spec: Optional[str] = None) -> Optional[tzinfo]:
             offset = -offset if sign == "-" else offset
             tz = timezone(timedelta(minutes=offset))
         elif "/" in tz_spec and sys.version_info >= (3, 9):
-            from zoneinfo import ZoneInfo  # requires python >= 3.9
+            from zoneinfo import ZoneInfo  # type: ignore[import-not-found]
 
             tz = ZoneInfo(tz_spec)  # Standard IANA timezone. Example: "Europe/Vienna"
         else:

--- a/bzfs_main/bzfs_jobrunner.py
+++ b/bzfs_main/bzfs_jobrunner.py
@@ -668,7 +668,15 @@ class Job:
         log.info("Succeeded. Bye!")
 
     def replication_opts(
-        self, dst_snapshot_plan, targets, lhn: str, src_hostname: str, dst_hostname: str, tag: str, job_id: str, job_run: str
+        self,
+        dst_snapshot_plan: Dict[str, Dict[str, Dict[str, int]]],
+        targets: Set[str],
+        lhn: str,
+        src_hostname: str,
+        dst_hostname: str,
+        tag: str,
+        job_id: str,
+        job_run: str,
     ) -> List[str]:
         log = self.log
         log.debug("%s", f"Replicating targets {sorted(targets)} from {src_hostname} to {dst_hostname} ...")

--- a/bzfs_tests/prune_bookmarks.py
+++ b/bzfs_tests/prune_bookmarks.py
@@ -21,7 +21,7 @@ import time
 from collections import defaultdict
 
 
-def main():
+def main() -> None:
     # fmt: off
     parser = argparse.ArgumentParser(
         description="Example ZFS bookmark pruning script that deletes the oldest bookmarks older than X days in a "

--- a/bzfs_tests/test_all.py
+++ b/bzfs_tests/test_all.py
@@ -24,7 +24,7 @@ from bzfs_tests.test_integrations import suite as test_integrations_suite
 from bzfs_main.bzfs import getenv_any
 
 
-def main():
+def main() -> None:
     suite = unittest.TestSuite()
     suite.addTests(test_utils_suite())
     suite.addTests(test_bzfs_suite())

--- a/bzfs_tests/test_bzfs.py
+++ b/bzfs_tests/test_bzfs.py
@@ -432,7 +432,7 @@ class TestHelperFunctions(unittest.TestCase):
         mock_kill.side_effect = err
         self.assertIsNone(bzfs.pid_exists(1234))
 
-    def test_delete_stale_files(self):
+    def test_delete_stale_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             new_socket_file = os.path.join(tmpdir, "s_new_socket_file")
             Path(new_socket_file).touch()
@@ -452,7 +452,7 @@ class TestHelperFunctions(unittest.TestCase):
             self.assertTrue(os.path.exists(sdir))
             self.assertTrue(os.path.exists(non_socket_file))
 
-    def test_delete_stale_files_ssh_alive(self):
+    def test_delete_stale_files_ssh_alive(self) -> None:
         """Socket file with a live pid (current process) should NOT be removed."""
         with tempfile.TemporaryDirectory() as tmpdir:
             socket_name = f"s{os.getpid()}foo"
@@ -470,7 +470,7 @@ class TestHelperFunctions(unittest.TestCase):
                 if os.path.exists(socket_path):
                     os.remove(socket_path)
 
-    def test_delete_stale_files_ssh_stale(self):
+    def test_delete_stale_files_ssh_stale(self) -> None:
         """Socket file with a non-existent pid should be removed."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # This fake PID is extremely unlikely to be alive because it is orders of magnitude higher than the typical
@@ -491,7 +491,7 @@ class TestHelperFunctions(unittest.TestCase):
                 if os.path.exists(socket_path):
                     os.remove(socket_path)
 
-    def test_delete_stale_files_ssh_regular_file(self):
+    def test_delete_stale_files_ssh_regular_file(self) -> None:
         """A regular file should be removed even when ssh=True."""
         with tempfile.TemporaryDirectory() as tmpdir:
             regular_file = os.path.join(tmpdir, "s_regular_file")
@@ -499,7 +499,7 @@ class TestHelperFunctions(unittest.TestCase):
             bzfs.delete_stale_files(tmpdir, "s", millis=0, ssh=True)
             self.assertFalse(os.path.exists(regular_file))
 
-    def test_set_last_modification_time(self):
+    def test_set_last_modification_time(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             file = os.path.join(tmpdir, "foo")
             bzfs.set_last_modification_time(file, unixtime_in_secs=0)
@@ -513,7 +513,7 @@ class TestHelperFunctions(unittest.TestCase):
             bzfs.set_last_modification_time_safe(file, unixtime_in_secs=1001, if_more_recent=True)
             self.assertEqual(1001, round(os.stat(file).st_mtime))
 
-    def test_set_last_modification_time_with_FileNotFoundError(self):
+    def test_set_last_modification_time_with_FileNotFoundError(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             file = os.path.join(tmpdir, "foo")
             with patch("bzfs_main.bzfs.os_utime", side_effect=FileNotFoundError):
@@ -522,7 +522,7 @@ class TestHelperFunctions(unittest.TestCase):
                 file = os.path.join(file, "x", "nonexisting2")
                 bzfs.set_last_modification_time_safe(file, unixtime_in_secs=1001, if_more_recent=False)
 
-    def test_recv_option_property_names(self):
+    def test_recv_option_property_names(self) -> None:
         def names(lst: List[str]) -> Set[str]:
             return bzfs.Job().recv_option_property_names(lst)
 
@@ -555,7 +555,7 @@ class TestHelperFunctions(unittest.TestCase):
         with self.assertRaises(SystemExit):
             names([" -o ", " -o ", "name1=value1"])
 
-    def test_fix_solaris_raw_mode(self):
+    def test_fix_solaris_raw_mode(self) -> None:
         self.assertListEqual(["-w", "none"], bzfs.fix_solaris_raw_mode(["-w"]))
         self.assertListEqual(["-w", "none"], bzfs.fix_solaris_raw_mode(["--raw"]))
         self.assertListEqual(["-w", "none"], bzfs.fix_solaris_raw_mode(["-w", "none"]))
@@ -565,7 +565,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertListEqual(["-w", "none", "foo"], bzfs.fix_solaris_raw_mode(["-w", "foo"]))
         self.assertListEqual(["-F"], bzfs.fix_solaris_raw_mode(["-F"]))
 
-    def test_get_logger_with_cleanup(self):
+    def test_get_logger_with_cleanup(self) -> None:
         def check(log: Logger, files: Set[str]) -> None:
             files_todo = files.copy()
             for handler in log.handlers:
@@ -626,7 +626,7 @@ class TestHelperFunctions(unittest.TestCase):
 
         bzfs.reset_logger()
 
-    def test_get_syslog_address(self):
+    def test_get_syslog_address(self) -> None:
         udp = socket.SOCK_DGRAM
         tcp = socket.SOCK_STREAM
         self.assertEqual((("localhost", 514), udp), bzfs.get_syslog_address("localhost:514", "UDP"))
@@ -634,12 +634,12 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual(("/dev/log", None), bzfs.get_syslog_address("/dev/log", "UDP"))
         self.assertEqual(("/dev/log", None), bzfs.get_syslog_address("/dev/log", "TCP"))
 
-    def test_validate_log_config_variable(self):
+    def test_validate_log_config_variable(self) -> None:
         self.assertIsNone(bzfs.validate_log_config_variable("name:value"))
         for var in ["noColon", ":noName", "$n:v", "{:v", "}:v", "", "  ", "\t", "a\tb:v", "spa ce:v", '"k":v', "'k':v"]:
             self.assertIsNotNone(bzfs.validate_log_config_variable(var))
 
-    def test_has_siblings(self):
+    def test_has_siblings(self) -> None:
         self.assertFalse(bzfs.has_siblings([]))
         self.assertFalse(bzfs.has_siblings(["a"]))
         self.assertFalse(bzfs.has_siblings(["a", "a/b"]))
@@ -653,7 +653,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertTrue(bzfs.has_siblings(["a", "a/b/c", "a/b/d"]))
         self.assertTrue(bzfs.has_siblings(["a", "a/b/c/d", "a/b/c/e"]))
 
-    def test_is_descendant(self):
+    def test_is_descendant(self) -> None:
         self.assertTrue(bzfs.is_descendant("pool/fs/child", "pool/fs"))
         self.assertTrue(bzfs.is_descendant("pool/fs/child/grandchild", "pool/fs"))
         self.assertTrue(bzfs.is_descendant("a/b/c/d", "a/b"))
@@ -669,7 +669,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertFalse(bzfs.is_descendant("pool/fs-backup", "pool/fs"))
         self.assertTrue(bzfs.is_descendant("pool/fs", "pool"))
 
-    def test_validate_default_shell(self):
+    def test_validate_default_shell(self) -> None:
         args = argparser_parse_args(args=["src", "dst"])
         p = bzfs.Params(args)
         remote = bzfs.Remote("src", args, p)
@@ -680,7 +680,7 @@ class TestHelperFunctions(unittest.TestCase):
         with self.assertRaises(SystemExit):
             bzfs.validate_default_shell("/bin/tcsh", remote)
 
-    def test_filter_datasets_with_test_mode_is_false(self):
+    def test_filter_datasets_with_test_mode_is_false(self) -> None:
         # test with Job.is_test_mode == False for coverage with the assertion therein disabled
         args = argparser_parse_args(args=["src", "dst"])
         p = bzfs.Params(args)
@@ -693,7 +693,7 @@ class TestHelperFunctions(unittest.TestCase):
         finally:
             bzfs.reset_logger()
 
-    def test_is_zfs_dataset_busy_match(self):
+    def test_is_zfs_dataset_busy_match(self) -> None:
         def is_busy(proc, dataset, busy_if_send: bool = True):
             return bzfs.Job().is_zfs_dataset_busy([proc], dataset, busy_if_send=busy_if_send)
 
@@ -721,7 +721,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual(bzfs.human_readable_float(actual), expected)
         self.assertEqual(bzfs.human_readable_float(-actual), "-" + expected)
 
-    def test_human_readable_float_with_one_digit_before_decimal(self):
+    def test_human_readable_float_with_one_digit_before_decimal(self) -> None:
         self.assert_human_readable_float(3.14159, "3.14")
         self.assert_human_readable_float(5.0, "5")
         self.assert_human_readable_float(0.5, "0.5")
@@ -731,13 +731,13 @@ class TestHelperFunctions(unittest.TestCase):
         self.assert_human_readable_float(2.5, "2.5")
         self.assert_human_readable_float(3.5, "3.5")
 
-    def test_human_readable_float_with_two_digits_before_decimal(self):
+    def test_human_readable_float_with_two_digits_before_decimal(self) -> None:
         self.assert_human_readable_float(12.34, "12.3")
         self.assert_human_readable_float(12.0, "12")
         self.assert_human_readable_float(12.54, "12.5")
         self.assert_human_readable_float(12.56, "12.6")
 
-    def test_human_readable_float_with_three_or_more_digits_before_decimal(self):
+    def test_human_readable_float_with_three_or_more_digits_before_decimal(self) -> None:
         self.assert_human_readable_float(123.456, "123")
         self.assert_human_readable_float(123.516, "124")
         self.assert_human_readable_float(1234.4678, "1234")
@@ -746,13 +746,13 @@ class TestHelperFunctions(unittest.TestCase):
         self.assert_human_readable_float(12345.678, "12346")
         self.assert_human_readable_float(999.99, "1000")
 
-    def test_human_readable_float_with_zero(self):
+    def test_human_readable_float_with_zero(self) -> None:
         self.assertEqual(bzfs.human_readable_float(0.0), "0")
         self.assertEqual(bzfs.human_readable_float(-0.0), "0")
         self.assertEqual(bzfs.human_readable_float(0.001), "0")
         self.assertEqual(bzfs.human_readable_float(-0.001), "0")
 
-    def test_human_readable_float_with_halfway_rounding_behavior(self):
+    def test_human_readable_float_with_halfway_rounding_behavior(self) -> None:
         # For |n| < 10 => 2 decimals
         self.assert_human_readable_float(1.15, "1.15")
         self.assert_human_readable_float(1.25, "1.25")
@@ -766,7 +766,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assert_human_readable_float(10.35 + eps, "10.4")
         self.assert_human_readable_float(10.45, "10.4")
 
-    def test_human_readable_bytes(self):
+    def test_human_readable_bytes(self) -> None:
         self.assertEqual("0 B", bzfs.human_readable_bytes(0))
         self.assertEqual("581 B", bzfs.human_readable_bytes(0.567 * 1024**1))
         self.assertEqual("2 KiB", bzfs.human_readable_bytes(2 * 1024**1))
@@ -785,7 +785,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual("2.57 B", bzfs.human_readable_bytes(2.567, precision=2))
         self.assertEqual("2.57 B", bzfs.human_readable_bytes(2.567, precision=None))
 
-    def test_human_readable_duration(self):
+    def test_human_readable_duration(self) -> None:
         ms = 1000_000
         self.assertEqual("0ns", bzfs.human_readable_duration(0, long=False))
         self.assertEqual("3ns", bzfs.human_readable_duration(3, long=False))
@@ -838,7 +838,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual("2.57ns", bzfs.human_readable_duration(2.567, precision=2))
         self.assertEqual("2.57ns", bzfs.human_readable_duration(2.567, precision=None))
 
-    def test_pv_cmd(self):
+    def test_pv_cmd(self) -> None:
         args = argparser_parse_args(args=["src", "dst"])
         log_params = bzfs.LogParams(args)
         try:
@@ -849,7 +849,7 @@ class TestHelperFunctions(unittest.TestCase):
         finally:
             bzfs.reset_logger()
 
-    def test_pv_size_to_bytes(self):
+    def test_pv_size_to_bytes(self) -> None:
         def pv_size_to_bytes(line: str) -> int:
             num_bytes, _ = bzfs.pv_size_to_bytes(line)
             return num_bytes
@@ -878,7 +878,7 @@ class TestHelperFunctions(unittest.TestCase):
         with self.assertRaises(ValueError):
             pv_size_to_bytes("4.12 KiB/s")
 
-    def test_count_num_bytes_transferred_by_pv(self):
+    def test_count_num_bytes_transferred_by_pv(self) -> None:
         default_opts = bzfs.argument_parser().get_default("pv_program_opts")
         self.assertTrue(isinstance(default_opts, str) and default_opts)
         pv_fd, pv_file = tempfile.mkstemp(prefix="test_bzfs.test_count_num_byte", suffix=".pv")
@@ -895,7 +895,7 @@ class TestHelperFunctions(unittest.TestCase):
         finally:
             Path(pv_file).unlink(missing_ok=True)
 
-    def test_count_num_bytes_transferred_by_zfs_send(self):
+    def test_count_num_bytes_transferred_by_zfs_send(self) -> None:
         self.assertEqual(0, bzfs.count_num_bytes_transferred_by_zfs_send("/tmp/nonexisting_bzfs_test_file"))
         for i in range(0, 2):
             with stop_on_failure_subtest(i=i):
@@ -919,7 +919,7 @@ class TestHelperFunctions(unittest.TestCase):
                     os.remove(pv2)
                     shutil.rmtree(pv3)
 
-    def test_progress_reporter_parse_pv_line(self):
+    def test_progress_reporter_parse_pv_line(self) -> None:
         args = argparser_parse_args(args=["src", "dst"])
         p = bzfs.Params(args)
         reporter = bzfs.ProgressReporter(p, use_select=False, progress_update_intervals=None)
@@ -1003,7 +1003,7 @@ class TestHelperFunctions(unittest.TestCase):
                     self.assertEqual(curr_time_nanos, eta_timestamp_nanos)
                     self.assertEqual("", line_tail)
 
-    def test_progress_reporter_update_transfer_stat(self):
+    def test_progress_reporter_update_transfer_stat(self) -> None:
         args = argparser_parse_args(args=["src", "dst"])
         p = bzfs.Params(args)
         curr_time_nanos = 123
@@ -1027,7 +1027,7 @@ class TestHelperFunctions(unittest.TestCase):
                 self.assertEqual(curr_time_nanos + 1_000_000_000 * (6 * 60 + 3), stat.eta.timestamp_nanos)
                 self.assertEqual("[>                   ]  2% ETA 0:06:03 ETA 17:27:49", stat.eta.line_tail)
 
-    def test_progress_reporter_stop(self):
+    def test_progress_reporter_stop(self) -> None:
         args = argparser_parse_args(args=["src", "dst"])
         log_params = bzfs.LogParams(args)
         try:
@@ -1055,7 +1055,7 @@ class TestHelperFunctions(unittest.TestCase):
         finally:
             bzfs.reset_logger()
 
-    def test_progress_reporter_exhausted_iterator_sees_appended_data(self):
+    def test_progress_reporter_exhausted_iterator_sees_appended_data(self) -> None:
         # Create a temporary file. We will keep the file descriptor from mkstemp open for the read iterator
         temp_file_fd_write, temp_file_path = tempfile.mkstemp(prefix="test_iterator_behavior_")
         try:
@@ -1105,7 +1105,7 @@ class TestHelperFunctions(unittest.TestCase):
             if os.path.exists(temp_file_path):
                 os.remove(temp_file_path)
 
-    def test_progress_reporter_state_with_reused_pv_file(self):
+    def test_progress_reporter_state_with_reused_pv_file(self) -> None:
         # We will manually call the reporter's update method to simulate its internal loop.
         mock_params = MagicMock(spec=bzfs.Params)
         reporter = bzfs.ProgressReporter(mock_params, use_select=False, progress_update_intervals=(0.01, 0.02))
@@ -1151,7 +1151,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual(total_bytes_op2, 200 * 1024, "Total bytes for Op2 incorrect")
         self.assertEqual(stat_obj_for_pv_log_file.bytes_in_flight, 0, "bytes_in_flight should be 0 after final line of Op2")
 
-    def test_reporter_handles_pv_log_file_disappearing_before_initial_open(self):
+    def test_reporter_handles_pv_log_file_disappearing_before_initial_open(self) -> None:
         # Test if ProgressReporter handles FileNotFoundError during the initial open of a pv_log_file.
         mock_params = MagicMock(spec=bzfs.Params)
         mock_params.log = MagicMock(spec=logging.Logger)
@@ -1184,7 +1184,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertSetEqual(set(), reporter.file_name_queue)
         self.assertIsNone(reporter.exception)
 
-    def test_has_duplicates(self):
+    def test_has_duplicates(self) -> None:
         self.assertFalse(bzfs.has_duplicates([]))
         self.assertFalse(bzfs.has_duplicates([42]))
         self.assertFalse(bzfs.has_duplicates([1, 2, 3, 4, 5]))
@@ -1209,7 +1209,7 @@ class TestHelperFunctions(unittest.TestCase):
                         return None
         return root_datasets
 
-    def test_root_datasets_if_recursive_zfs_snapshot_is_possible(self):
+    def test_root_datasets_if_recursive_zfs_snapshot_is_possible(self) -> None:
         def run_filter(src_datasets: List[str], basis_src_datasets: List[str]) -> Optional[List[str]]:
             assert set(src_datasets).issubset(set(basis_src_datasets))
             src_datasets = list(sorted(src_datasets))
@@ -1297,7 +1297,7 @@ class TestHelperFunctions(unittest.TestCase):
             ["a/B", "a/D", "a/X"], cast(List[str], run_filter(["a/B", "a/B/c", "a/X", "a/X/c", "a/D"], basis_src_datasets))
         )
 
-    def test_validate_snapshot_name(self):
+    def test_validate_snapshot_name(self) -> None:
         bzfs.SnapshotLabel("foo_", "", "", "").validate_label("")
         bzfs.SnapshotLabel("foo_", "", "", "_foo").validate_label("")
         bzfs.SnapshotLabel("foo_", "foo_", "", "_foo").validate_label("")
@@ -1321,7 +1321,7 @@ class TestHelperFunctions(unittest.TestCase):
             bzfs.SnapshotLabel("foo/bar_", "", "", "").validate_label("")
         self.assertTrue(str(bzfs.SnapshotLabel("foo_", "", "", "")))
 
-    def test_label_milliseconds(self):
+    def test_label_milliseconds(self) -> None:
         xperiods = bzfs.SnapshotPeriods()
         self.assertEqual(xperiods.suffix_milliseconds["yearly"] * 1, xperiods.label_milliseconds("foo_yearly"))
         self.assertEqual(xperiods.suffix_milliseconds["yearly"] * 2, xperiods.label_milliseconds("foo_2yearly"))
@@ -1339,7 +1339,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual(xperiods.suffix_milliseconds["secondly"], xperiods.label_milliseconds("foo_secondly"))
         self.assertEqual(xperiods.suffix_milliseconds["millisecondly"], xperiods.label_milliseconds("foo_millisecondly"))
 
-    def test_CreateSrcSnapshotConfig(self):
+    def test_CreateSrcSnapshotConfig(self) -> None:
         params = bzfs.Params(argparser_parse_args(args=["src", "dst"]))
         good_args = bzfs.argument_parser().parse_args(
             [
@@ -1524,7 +1524,7 @@ class TestHelperFunctions(unittest.TestCase):
         with self.assertRaises(SystemExit):
             bzfs.CreateSrcSnapshotConfig(args, bzfs.Params(args))
 
-    def test_MonitorSnapshotsConfig(self):
+    def test_MonitorSnapshotsConfig(self) -> None:
         def plan(alerts) -> str:
             return str({"z": {"onsite": {"100millisecondly": alerts}}})
 
@@ -1669,7 +1669,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertTrue(config.dont_crit)
 
     @patch("bzfs_main.bzfs.Job.itr_ssh_cmd_parallel")
-    def test_zfs_get_snapshots_changed_parsing(self, mock_itr_parallel):
+    def test_zfs_get_snapshots_changed_parsing(self, mock_itr_parallel) -> None:
         job = bzfs.Job()
         job.params = bzfs.Params(argparser_parse_args(args=["src", "dst"]))
         self.mock_remote = MagicMock(spec=bzfs.Remote)  # spec helps catch calls to non-existent attrs
@@ -1729,14 +1729,14 @@ class TestTerminateProcessSubtree(unittest.TestCase):
                 pass
         self.children = []
 
-    def test_get_descendant_processes(self):
+    def test_get_descendant_processes(self) -> None:
         child = subprocess.Popen(["sleep", "1"])
         self.children.append(child)
         time.sleep(0.1)
         descendants = bzfs.get_descendant_processes(os.getpid())
         self.assertIn(child.pid, descendants, "Child PID not found in descendants")
 
-    def test_terminate_process_subtree_excluding_current(self):
+    def test_terminate_process_subtree_excluding_current(self) -> None:
         child = subprocess.Popen(["sleep", "1"])
         self.children.append(child)
         time.sleep(0.1)
@@ -1748,40 +1748,40 @@ class TestTerminateProcessSubtree(unittest.TestCase):
 
 #############################################################################
 class TestSubprocessRun(unittest.TestCase):
-    def test_successful_command(self):
+    def test_successful_command(self) -> None:
         result = bzfs.subprocess_run(["true"], stdout=PIPE, stderr=PIPE)
         self.assertEqual(0, result.returncode)
         self.assertEqual(b"", result.stdout)
         self.assertEqual(b"", result.stderr)
 
-    def test_failing_command_no_check(self):
+    def test_failing_command_no_check(self) -> None:
         result = bzfs.subprocess_run(["false"], stdout=PIPE, stderr=PIPE)
         self.assertNotEqual(0, result.returncode)
         self.assertEqual(b"", result.stdout)
         self.assertEqual(b"", result.stderr)
 
-    def test_failing_command_with_check(self):
+    def test_failing_command_with_check(self) -> None:
         with self.assertRaises(subprocess.CalledProcessError) as context:
             bzfs.subprocess_run(["false"], stdout=PIPE, stderr=PIPE, check=True)
         self.assertIsInstance(context.exception, subprocess.CalledProcessError)
         self.assertIsInstance(context.exception.returncode, int)
         self.assertTrue(context.exception.returncode != 0)
 
-    def test_input_bytes(self):
+    def test_input_bytes(self) -> None:
         result = bzfs.subprocess_run(["cat"], input=b"hello", stdout=PIPE, stderr=PIPE)
         self.assertEqual(b"hello", result.stdout)
 
-    def test_valueerror_input_and_stdin(self):
+    def test_valueerror_input_and_stdin(self) -> None:
         with self.assertRaises(ValueError):
             bzfs.subprocess_run(["cat"], input=b"hello", stdin=PIPE, stdout=PIPE, stderr=PIPE)
 
-    def test_timeout_expired(self):
+    def test_timeout_expired(self) -> None:
         with self.assertRaises(subprocess.TimeoutExpired) as context:
             bzfs.subprocess_run(["sleep", "1"], timeout=0.01, stdout=PIPE, stderr=PIPE)
         self.assertIsInstance(context.exception, subprocess.TimeoutExpired)
         self.assertEqual(["sleep", "1"], context.exception.cmd)
 
-    def test_keyboardinterrupt_signal(self):
+    def test_keyboardinterrupt_signal(self) -> None:
         old_handler = signal.signal(signal.SIGINT, signal.default_int_handler)  # install a handler that ignores SIGINT
         try:
 
@@ -1834,7 +1834,7 @@ class TestParseDatasetLocator(unittest.TestCase):
             )
             self.fail()
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         # Input format is [[user@]host:]dataset
         # test columns indicate values for: input | user | host | dataset | userhost | validationError
         self.run_test(
@@ -1953,48 +1953,48 @@ class TestReplaceCapturingGroups(unittest.TestCase):
     def replace_capturing_group(self, regex: str) -> str:
         return bzfs.replace_capturing_groups_with_non_capturing_groups(regex)
 
-    def test_basic_case(self):
+    def test_basic_case(self) -> None:
         self.assertEqual(self.replace_capturing_group("(abc)"), "(?:abc)")
 
-    def test_nested_groups(self):
+    def test_nested_groups(self) -> None:
         self.assertEqual(self.replace_capturing_group("(a(bc)d)"), "(?:a(?:bc)d)")
 
-    def test_preceding_backslash(self):
+    def test_preceding_backslash(self) -> None:
         self.assertEqual(self.replace_capturing_group("\\(abc)"), "\\(abc)")
 
-    def test_group_starting_with_question_mark(self):
+    def test_group_starting_with_question_mark(self) -> None:
         self.assertEqual(self.replace_capturing_group("(?abc)"), "(?abc)")
 
-    def test_multiple_groups(self):
+    def test_multiple_groups(self) -> None:
         self.assertEqual(self.replace_capturing_group("(abc)(def)"), "(?:abc)(?:def)")
 
-    def test_mixed_cases(self):
+    def test_mixed_cases(self) -> None:
         self.assertEqual(self.replace_capturing_group("a(bc\\(de)f(gh)?i"), "a(?:bc\\(de)f(?:gh)?i")
 
-    def test_empty_group(self):
+    def test_empty_group(self) -> None:
         self.assertEqual(self.replace_capturing_group("()"), "(?:)")
 
-    def test_group_with_named_group(self):
+    def test_group_with_named_group(self) -> None:
         self.assertEqual(self.replace_capturing_group("(?P<name>abc)"), "(?P<name>abc)")
 
-    def test_group_with_non_capturing_group(self):
+    def test_group_with_non_capturing_group(self) -> None:
         self.assertEqual(self.replace_capturing_group("(a(?:bc)d)"), "(?:a(?:bc)d)")
 
-    def test_group_with_lookahead(self):
+    def test_group_with_lookahead(self) -> None:
         self.assertEqual(self.replace_capturing_group("(abc)(?=def)"), "(?:abc)(?=def)")
 
-    def test_group_with_lookbehind(self):
+    def test_group_with_lookbehind(self) -> None:
         self.assertEqual(self.replace_capturing_group("(?<=abc)(def)"), "(?<=abc)(?:def)")
 
-    def test_escaped_characters(self):
+    def test_escaped_characters(self) -> None:
         pattern = re.escape("(abc)")
         self.assertEqual(self.replace_capturing_group(pattern), pattern)
 
-    def test_complex_pattern_with_escape(self):
+    def test_complex_pattern_with_escape(self) -> None:
         complex_pattern = re.escape("(a[b]c{d}e|f.g)")
         self.assertEqual(self.replace_capturing_group(complex_pattern), complex_pattern)
 
-    def test_complex_pattern(self):
+    def test_complex_pattern(self) -> None:
         complex_pattern = "(a[b]c{d}e|f.g)(h(i|j)k)?(\\(l\\))"
         expected_result = "(?:a[b]c{d}e|f.g)(?:h(?:i|j)k)?(?:\\(l\\))"
         self.assertEqual(self.replace_capturing_group(complex_pattern), expected_result)
@@ -2009,47 +2009,47 @@ class TestBuildTree(unittest.TestCase):
             if isinstance(value, dict):
                 self.assert_keys_sorted(value)
 
-    def test_basic_tree(self):
+    def test_basic_tree(self) -> None:
         datasets = ["pool", "pool/dataset", "pool/dataset/sub", "pool/other", "pool/other/sub/child"]
         expected_tree = {"pool": {"dataset": {"sub": {}}, "other": {"sub": {"child": {}}}}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_empty_input(self):
+    def test_empty_input(self) -> None:
         datasets: List[str] = []
         expected_tree: bzfs.Tree = {}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
 
-    def test_single_root(self):
+    def test_single_root(self) -> None:
         datasets: List[str] = ["pool"]
         expected_tree: bzfs.Tree = {"pool": {}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_single_branch(self):
+    def test_single_branch(self) -> None:
         datasets: List[str] = ["pool/dataset/sub/child"]
         expected_tree: bzfs.Tree = {"pool": {"dataset": {"sub": {"child": {}}}}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_multiple_roots(self):
+    def test_multiple_roots(self) -> None:
         datasets: List[str] = ["pool", "otherpool", "anotherpool"]
         expected_tree: bzfs.Tree = {"anotherpool": {}, "otherpool": {}, "pool": {}}
         tree = bzfs.Job().build_dataset_tree(sorted(datasets))
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_large_dataset(self):
+    def test_large_dataset(self) -> None:
         datasets: List[str] = [f"pool/dataset{i}" for i in range(100)]
         tree = bzfs.Job().build_dataset_tree(sorted(datasets))
         self.assertEqual(len(tree["pool"]), 100)
         self.assert_keys_sorted(tree)
 
-    def test_nested_structure(self):
+    def test_nested_structure(self) -> None:
         datasets: List[str] = [
             "pool/parent",
             "pool/parent/child1",
@@ -2062,49 +2062,49 @@ class TestBuildTree(unittest.TestCase):
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_no_children(self):
+    def test_no_children(self) -> None:
         datasets: List[str] = ["pool", "otherpool"]
         expected_tree: bzfs.Tree = {"otherpool": {}, "pool": {}}
         tree = bzfs.Job().build_dataset_tree(sorted(datasets))
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_single_level(self):
+    def test_single_level(self) -> None:
         datasets: List[str] = ["pool", "pool1", "pool2", "pool3"]
         expected_tree: bzfs.Tree = {"pool": {}, "pool1": {}, "pool2": {}, "pool3": {}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_multiple_roots_with_hierarchy(self):
+    def test_multiple_roots_with_hierarchy(self) -> None:
         datasets: List[str] = ["pool", "pool1", "pool1/dataset1", "pool2", "pool2/dataset2", "pool2/dataset2/sub", "pool3"]
         expected_tree: bzfs.Tree = {"pool": {}, "pool1": {"dataset1": {}}, "pool2": {"dataset2": {"sub": {}}}, "pool3": {}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_multiple_roots_flat(self):
+    def test_multiple_roots_flat(self) -> None:
         datasets: List[str] = ["root1", "root2", "root3", "root4"]
         expected_tree: bzfs.Tree = {"root1": {}, "root2": {}, "root3": {}, "root4": {}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_multiple_roots_mixed_depth(self):
+    def test_multiple_roots_mixed_depth(self) -> None:
         datasets: List[str] = ["a", "a/b", "a/b/c", "x", "x/y", "z", "z/1", "z/2", "z/2/3"]
         expected_tree: bzfs.Tree = {"a": {"b": {"c": {}}}, "x": {"y": {}}, "z": {"1": {}, "2": {"3": {}}}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_tree_with_missing_intermediate_nodes(self):
+    def test_tree_with_missing_intermediate_nodes(self) -> None:
         datasets: List[str] = ["a", "a/b/c", "z/2/3"]
         expected_tree: bzfs.Tree = {"a": {"b": {"c": {}}}, "z": {"2": {"3": {}}}}
         tree = bzfs.Job().build_dataset_tree(datasets)
         self.assertEqual(tree, expected_tree)
         self.assert_keys_sorted(tree)
 
-    def test_tree_with_barriers(self):
+    def test_tree_with_barriers(self) -> None:
         BR = bzfs.BARRIER_CHAR
         datasets: List[str] = [
             "a/b/c",
@@ -2128,7 +2128,7 @@ class TestCurrentDateTime(unittest.TestCase):
     def setUp(self) -> None:
         self.fixed_datetime = datetime(2024, 1, 1, 12, 0, 0)  # in no timezone
 
-    def test_now(self):
+    def test_now(self) -> None:
         self.assertIsNotNone(bzfs.current_datetime(tz_spec=None, now_fn=None))
         self.assertIsNotNone(bzfs.current_datetime(tz_spec="UTC", now_fn=None))
         self.assertIsNotNone(bzfs.current_datetime(tz_spec="+0530", now_fn=None))
@@ -2136,7 +2136,7 @@ class TestCurrentDateTime(unittest.TestCase):
         self.assertIsNotNone(bzfs.current_datetime(tz_spec="-0430", now_fn=None))
         self.assertIsNotNone(bzfs.current_datetime(tz_spec="-04:30", now_fn=None))
 
-    def test_local_timezone(self):
+    def test_local_timezone(self) -> None:
         expected = self.fixed_datetime.astimezone(tz=None)
 
         def now_fn(tz: Optional[tzinfo]) -> datetime:
@@ -2163,7 +2163,7 @@ class TestCurrentDateTime(unittest.TestCase):
         self.assertIn(suffix[0], ["+", "-"])
         self.assertTrue(suffix[1:].isdigit())
 
-    def test_utc_timezone(self):
+    def test_utc_timezone(self) -> None:
         expected = self.fixed_datetime.astimezone(tz=timezone.utc)
 
         def now_fn(tz: Optional[tzinfo] = None) -> datetime:
@@ -2172,7 +2172,7 @@ class TestCurrentDateTime(unittest.TestCase):
         actual = bzfs.current_datetime(tz_spec="UTC", now_fn=now_fn)
         self.assertEqual(expected, actual)
 
-    def test_tzoffset_positive(self):
+    def test_tzoffset_positive(self) -> None:
         tz_spec = "+0530"
         tz = timezone(timedelta(hours=5, minutes=30))
         expected = self.fixed_datetime.astimezone(tz=tz)
@@ -2183,7 +2183,7 @@ class TestCurrentDateTime(unittest.TestCase):
         actual = bzfs.current_datetime(tz_spec=tz_spec, now_fn=now_fn)
         self.assertEqual(expected, actual)
 
-    def test_tzoffset_negative(self):
+    def test_tzoffset_negative(self) -> None:
         tz_spec = "-0430"
         tz = timezone(timedelta(hours=-4, minutes=-30))
         expected = self.fixed_datetime.astimezone(tz=tz)
@@ -2194,7 +2194,7 @@ class TestCurrentDateTime(unittest.TestCase):
         actual = bzfs.current_datetime(tz_spec=tz_spec, now_fn=now_fn)
         self.assertEqual(expected, actual)
 
-    def test_iana_timezone(self):
+    def test_iana_timezone(self) -> None:
         if sys.version_info < (3, 9):
             self.skipTest("ZoneInfo requires python >= 3.9")
         from zoneinfo import ZoneInfo  # requires python >= 3.9
@@ -2212,12 +2212,12 @@ class TestCurrentDateTime(unittest.TestCase):
         self.assertIn(suffix[0], ["+", "-"])
         self.assertTrue(suffix[1:].isdigit())
 
-    def test_invalid_timezone(self):
+    def test_invalid_timezone(self) -> None:
         with self.assertRaises(ValueError) as context:
             bzfs.current_datetime(tz_spec="INVALID")
         self.assertIn("Invalid timezone specification", str(context.exception))
 
-    def test_invalid_timezone_format_missing_sign(self):
+    def test_invalid_timezone_format_missing_sign(self) -> None:
         with self.assertRaises(ValueError):
             bzfs.current_datetime(tz_spec="0400")
 
@@ -2234,7 +2234,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         # Use a fixed timezone (e.g. Eastern Standard Time, UTC-5) for all tests.
         self.tz = timezone(timedelta(hours=-5))
 
-    def test_examples(self):
+    def test_examples(self) -> None:
         def make_dt(hour: int, minute: int, second: int) -> datetime:
             return datetime(2024, 11, 29, hour, minute, second, 0, tzinfo=self.tz)
 
@@ -2289,7 +2289,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         dt = make_dt(hour=23, minute=55, second=1)
         self.assertEqual(dt.replace(day=dt.day + 1, hour=0, minute=0, second=0), round_up(dt, duration_amount=2))
 
-    def test_zero_unixtime(self):
+    def test_zero_unixtime(self) -> None:
         dt = datetime.fromtimestamp(0, tz=timezone.utc)
         result = round_datetime_up_to_duration_multiple(dt, 1, "hourly")
         expected = dt
@@ -2303,7 +2303,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         self.assertEqual(expected, result)
         self.assertEqual(tz, result.tzinfo)
 
-    def test_zero_unixtime_plus_one_microsecond(self):
+    def test_zero_unixtime_plus_one_microsecond(self) -> None:
         dt = datetime.fromtimestamp(1 / 1_000_000, tz=timezone.utc)
         result = round_datetime_up_to_duration_multiple(dt, 1, "hourly")
         expected = dt.replace(microsecond=0) + timedelta(hours=1)
@@ -2317,14 +2317,14 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         self.assertEqual(expected, result)
         self.assertEqual(tz, result.tzinfo)
 
-    def test_zero_duration_amount(self):
+    def test_zero_duration_amount(self) -> None:
         dt = datetime(2025, 2, 11, 14, 5, 1, 123456, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 0, "hourly")
         expected = dt
         self.assertEqual(expected, result)
         self.assertEqual(self.tz, result.tzinfo)
 
-    def test_milliseconds_non_boundary(self):
+    def test_milliseconds_non_boundary(self) -> None:
         """Rounding up to the next millisecond when dt is not on a millisecond boundary."""
         dt = datetime(2025, 2, 11, 14, 5, 1, 123456, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "millisecondly")
@@ -2332,13 +2332,13 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         self.assertEqual(expected, result)
         self.assertEqual(self.tz, result.tzinfo)
 
-    def test_milliseconds_boundary(self):
+    def test_milliseconds_boundary(self) -> None:
         """Rounding up to the next second when dt is exactly on a second boundary returns dt."""
         dt = datetime(2025, 2, 11, 14, 5, 1, 123000, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "millisecondly")
         self.assertEqual(dt, result)
 
-    def test_seconds_non_boundary(self):
+    def test_seconds_non_boundary(self) -> None:
         """Rounding up to the next second when dt is not on a second boundary."""
         dt = datetime(2025, 2, 11, 14, 5, 1, 123456, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "secondly")
@@ -2346,112 +2346,112 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         self.assertEqual(expected, result)
         self.assertEqual(self.tz, result.tzinfo)
 
-    def test_seconds_boundary(self):
+    def test_seconds_boundary(self) -> None:
         """Rounding up to the next second when dt is exactly on a second boundary returns dt."""
         dt = datetime(2025, 2, 11, 14, 5, 1, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "secondly")
         self.assertEqual(dt, result)
 
-    def test_minutes_non_boundary(self):
+    def test_minutes_non_boundary(self) -> None:
         """Rounding up to the next minute when dt is not on a minute boundary."""
         dt = datetime(2025, 2, 11, 14, 5, 1, 500000, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "minutely")
         expected = dt.replace(second=0, microsecond=0) + timedelta(minutes=1)
         self.assertEqual(expected, result)
 
-    def test_minutes_boundary(self):
+    def test_minutes_boundary(self) -> None:
         """Rounding up to the next minute when dt is exactly on a minute boundary returns dt."""
         dt = datetime(2025, 2, 11, 14, 5, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "minutely")
         self.assertEqual(dt, result)
 
-    def test_hours_non_boundary(self):
+    def test_hours_non_boundary(self) -> None:
         """Rounding up to the next hour when dt is not on an hour boundary."""
         dt = datetime(2025, 2, 11, 14, 5, 1, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "hourly")
         expected = dt.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
         self.assertEqual(expected, result)
 
-    def test_hours_non_boundary2(self):
+    def test_hours_non_boundary2(self) -> None:
         """Rounding up to the next hour when dt is not on an hour boundary."""
         dt = datetime(2025, 2, 11, 0, 5, 1, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "hourly", PeriodAnchors(**{"hourly_minute": 59}))
         expected = dt.replace(minute=59, second=0, microsecond=0) + timedelta(hours=0)
         self.assertEqual(expected, result)
 
-    def test_hours_non_boundary3(self):
+    def test_hours_non_boundary3(self) -> None:
         """Rounding up to the next hour when dt is not on an hour boundary."""
         dt = datetime(2025, 2, 11, 2, 5, 1, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "hourly", PeriodAnchors(**{"hourly_minute": 59}))
         expected = dt.replace(minute=59, second=0, microsecond=0) + timedelta(hours=0)
         self.assertEqual(expected, result)
 
-    def test_hours_boundary(self):
+    def test_hours_boundary(self) -> None:
         """Rounding up to the next hour when dt is exactly on an hour boundary returns dt."""
         dt = datetime(2025, 2, 11, 14, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "hourly")
         self.assertEqual(dt, result)
 
-    def test_days_non_boundary(self):
+    def test_days_non_boundary(self) -> None:
         """Rounding up to the next day when dt is not on a day boundary."""
         dt = datetime(2025, 2, 11, 14, 5, 1, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "daily")
         expected = dt.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
         self.assertEqual(expected, result)
 
-    def test_days_non_boundary2(self):
+    def test_days_non_boundary2(self) -> None:
         """Rounding up to the next day when dt is not on a day boundary."""
         dt = datetime(2025, 2, 11, 1, 59, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "daily", PeriodAnchors(**{"daily_hour": 2}))
         expected = dt.replace(hour=2, minute=0, second=0, microsecond=0) + timedelta(days=0)
         self.assertEqual(expected, result)
 
-    def test_days_boundary(self):
+    def test_days_boundary(self) -> None:
         """Rounding up to the next day when dt is exactly at midnight returns dt."""
         dt = datetime(2025, 2, 11, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "daily")
         self.assertEqual(dt, result)
 
-    def test_weeks_non_boundary_saturday(self):
+    def test_weeks_non_boundary_saturday(self) -> None:
         # anchor is the most recent between Friday and Saturday
         dt = datetime(2025, 2, 11, 14, 5, 1, tzinfo=self.tz)  # Tuesday
         expected = datetime(2025, 2, 15, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "weekly", anchors=bzfs.PeriodAnchors(weekly_weekday=6))
         self.assertEqual(expected, result)
 
-    def test_weeks_non_boundary_sunday(self):
+    def test_weeks_non_boundary_sunday(self) -> None:
         # anchor is the most recent midnight between Saturday and Sunday
         dt = datetime(2025, 2, 11, 14, 5, 1, tzinfo=self.tz)  # Tuesday
         expected = datetime(2025, 2, 16, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "weekly", anchors=bzfs.PeriodAnchors(weekly_weekday=0))
         self.assertEqual(expected, result)
 
-    def test_weeks_non_boundary_monday(self):
+    def test_weeks_non_boundary_monday(self) -> None:
         # anchor is the most recent midnight between Sunday and Monday
         dt = datetime(2025, 2, 11, 14, 5, 1, tzinfo=self.tz)  # Tuesday
         expected = datetime(2025, 2, 17, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "weekly", anchors=bzfs.PeriodAnchors(weekly_weekday=1))
         self.assertEqual(expected, result)
 
-    def test_weeks_boundary_saturday(self):
+    def test_weeks_boundary_saturday(self) -> None:
         # dt is exactly at midnight between Friday and Saturday
         dt = datetime(2025, 2, 15, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "weekly", anchors=bzfs.PeriodAnchors(weekly_weekday=6))
         self.assertEqual(dt, result)
 
-    def test_weeks_boundary_sunday(self):
+    def test_weeks_boundary_sunday(self) -> None:
         # dt is exactly at midnight between Saturday and Sunday
         dt = datetime(2025, 2, 16, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "weekly", anchors=bzfs.PeriodAnchors(weekly_weekday=0))
         self.assertEqual(dt, result)
 
-    def test_weeks_boundary_monday(self):
+    def test_weeks_boundary_monday(self) -> None:
         # dt is exactly at midnight between Sunday and Monday
         dt = datetime(2025, 2, 17, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "weekly", anchors=bzfs.PeriodAnchors(weekly_weekday=1))
         self.assertEqual(dt, result)
 
-    def test_months_non_boundary2a(self):
+    def test_months_non_boundary2a(self) -> None:
         """Rounding up to the next multiple of months when dt is not on a boundary."""
         # For a 2-month step, using dt = March 15, 2025 should round up to May 1, 2025.
         dt = datetime(2025, 3, 15, 10, 30, tzinfo=self.tz)
@@ -2459,7 +2459,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         expected = datetime(2025, 5, 1, 0, 0, 0, tzinfo=self.tz)
         self.assertEqual(expected, result)
 
-    def test_months_non_boundary2b(self):
+    def test_months_non_boundary2b(self) -> None:
         """Rounding up to the next multiple of months when dt is not on a boundary."""
         # For a 2-month step, using dt = April 15, 2025 should round up to June 1, 2025.
         dt = datetime(2025, 4, 15, 10, 30, tzinfo=self.tz)
@@ -2467,13 +2467,13 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         expected = datetime(2025, 6, 1, 0, 0, 0, tzinfo=self.tz)
         self.assertEqual(expected, result)
 
-    def test_months_boundary(self):
+    def test_months_boundary(self) -> None:
         """When dt is exactly on a month boundary that is a multiple, dt is returned unchanged."""
         dt = datetime(2025, 3, 1, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 2, "monthly")
         self.assertEqual(dt, result)
 
-    def test_years_non_boundary2a(self):
+    def test_years_non_boundary2a(self) -> None:
         """Rounding up to the next multiple of years when dt is not on a boundary."""
         # For a 2-year step, using dt = Feb 11, 2024 should round up to Jan 1, 2025.
         dt = datetime(2024, 2, 11, 14, 5, tzinfo=self.tz)
@@ -2481,7 +2481,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         expected = datetime(2026, 1, 1, 0, 0, 0, tzinfo=self.tz)
         self.assertEqual(expected, result)
 
-    def test_years_non_boundary2b(self):
+    def test_years_non_boundary2b(self) -> None:
         """Rounding up to the next multiple of years when dt is not on a boundary."""
         # For a 2-year step, using dt = Feb 11, 2025 should round up to Jan 1, 2027.
         dt = datetime(2025, 2, 11, 14, 5, tzinfo=self.tz)
@@ -2489,26 +2489,26 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         expected = datetime(2027, 1, 1, 0, 0, 0, tzinfo=self.tz)
         self.assertEqual(expected, result)
 
-    def test_years_boundary(self):
+    def test_years_boundary(self) -> None:
         """When dt is exactly on a year boundary that is a multiple, dt is returned unchanged."""
         # January 1, 2025 is on a valid boundary if (2025-1) % 2 == 0.
         dt = datetime(2025, 1, 1, 0, 0, 0, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 2, "yearly")
         self.assertEqual(dt, result)
 
-    def test_invalid_unit(self):
+    def test_invalid_unit(self) -> None:
         """Passing an unsupported time unit should raise a ValueError."""
         dt = datetime(2025, 2, 11, 14, 5, tzinfo=self.tz)
         with self.assertRaises(ValueError):
             round_datetime_up_to_duration_multiple(dt, 2, "fortnights")
 
-    def test_preserves_timezone(self):
+    def test_preserves_timezone(self) -> None:
         """The returned datetime must have the same timezone as the input."""
         dt = datetime(2025, 2, 11, 14, 5, 1, tzinfo=self.tz)
         result = round_datetime_up_to_duration_multiple(dt, 1, "hourly")
         self.assertEqual(dt.tzinfo, result.tzinfo)
 
-    def test_custom_hourly_anchor(self):
+    def test_custom_hourly_anchor(self) -> None:
         # Custom hourly: snapshots occur at :15:30 each hour.
         dt = datetime(2025, 2, 11, 14, 20, 0, tzinfo=self.tz)
         # Global base (daily) is 00:00:00, so effective hourly base = 00:15:30.
@@ -2519,7 +2519,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_custom_hourly_anchor2a(self):
+    def test_custom_hourly_anchor2a(self) -> None:
         # Custom hourly: snapshots occur at :15:30 every other hour.
         dt = datetime(2025, 2, 11, 14, 20, 0, tzinfo=self.tz)
         # Global base (daily) is 00:00:00, so effective hourly base = 00:15:30.
@@ -2530,7 +2530,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_custom_hourly_anchor2b(self):
+    def test_custom_hourly_anchor2b(self) -> None:
         # Custom hourly: snapshots occur at :15:30 every other hour.
         dt = datetime(2025, 2, 11, 15, 20, 0, tzinfo=self.tz)
         # Global base (daily) is 00:00:00, so effective hourly base = 00:15:30.
@@ -2541,7 +2541,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_custom_daily_anchor(self):
+    def test_custom_daily_anchor(self) -> None:
         # Custom daily: snapshots occur at 01:30:00.
         custom = bzfs.PeriodAnchors(daily_hour=1, daily_minute=30, daily_second=0)
         dt = datetime(2025, 2, 11, 0, 45, 0, tzinfo=self.tz)
@@ -2553,7 +2553,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 1, "daily", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_weekly_anchor1a(self):
+    def test_custom_weekly_anchor1a(self) -> None:
         # Custom weekly: every week, weekly_weekday=2, weekly time = 03:00:00.
         custom = bzfs.PeriodAnchors(weekly_weekday=2, weekly_hour=3, weekly_minute=0, weekly_second=0)
         dt = datetime(2025, 2, 13, 5, 0, 0, tzinfo=self.tz)  # Thursday
@@ -2562,7 +2562,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 1, "weekly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_monthly_anchor1a(self):
+    def test_custom_monthly_anchor1a(self) -> None:
         # Custom monthly: snapshots every month on the 15th at 12:00:00.
         custom = bzfs.PeriodAnchors(monthly_monthday=15, monthly_hour=12, monthly_minute=0, monthly_second=0)
         dt = datetime(2025, 4, 20, 10, 0, 0, tzinfo=self.tz)
@@ -2570,7 +2570,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 1, "monthly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_monthly_anchor1b(self):
+    def test_custom_monthly_anchor1b(self) -> None:
         # Custom monthly: snapshots every month on the 15th at 12:00:00.
         custom = bzfs.PeriodAnchors(monthly_monthday=15, monthly_hour=12, monthly_minute=0, monthly_second=0)
         dt = datetime(2025, 5, 12, 10, 0, 0, tzinfo=self.tz)
@@ -2578,7 +2578,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 1, "monthly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_monthly_anchor2a(self):
+    def test_custom_monthly_anchor2a(self) -> None:
         # Custom monthly: snapshots every other month on the 15th at 12:00:00.
         custom = bzfs.PeriodAnchors(monthly_monthday=15, monthly_hour=12, monthly_minute=0, monthly_second=0)
         dt = datetime(2025, 4, 20, 10, 0, 0, tzinfo=self.tz)
@@ -2586,7 +2586,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 2, "monthly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_monthly_anchor2b(self):
+    def test_custom_monthly_anchor2b(self) -> None:
         # Custom monthly: snapshots every other month on the 15th at 12:00:00.
         custom = bzfs.PeriodAnchors(monthly_monthday=15, monthly_hour=12, monthly_minute=0, monthly_second=0)
         dt = datetime(2025, 5, 12, 10, 0, 0, tzinfo=self.tz)
@@ -2594,7 +2594,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 2, "monthly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_monthly_anchor2c(self):
+    def test_custom_monthly_anchor2c(self) -> None:
         # Custom monthly: snapshots every other month on the 15th at 12:00:00.
         custom = bzfs.PeriodAnchors(monthly_monthday=15, monthly_hour=12, monthly_minute=0, monthly_second=0)
         dt = datetime(2025, 5, 17, 10, 0, 0, tzinfo=self.tz)
@@ -2602,7 +2602,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 2, "monthly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_yearly_anchor1a(self):
+    def test_custom_yearly_anchor1a(self) -> None:
         # Custom yearly: snapshots on June 30 at 02:00:00.
         custom = bzfs.PeriodAnchors(yearly_month=6, yearly_monthday=30, yearly_hour=2, yearly_minute=0, yearly_second=0)
         dt = datetime(2024, 3, 15, 10, 0, 0, tzinfo=self.tz)
@@ -2610,7 +2610,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 1, "yearly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_yearly_anchor1b(self):
+    def test_custom_yearly_anchor1b(self) -> None:
         # Custom yearly: snapshots on June 30 at 02:00:00.
         custom = bzfs.PeriodAnchors(yearly_month=6, yearly_monthday=30, yearly_hour=2, yearly_minute=0, yearly_second=0)
         dt = datetime(2025, 3, 15, 10, 0, 0, tzinfo=self.tz)
@@ -2618,7 +2618,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 1, "yearly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_yearly_anchor2a(self):
+    def test_custom_yearly_anchor2a(self) -> None:
         # Custom yearly: snapshots every other year on June 30 at 02:00:00.
         custom = bzfs.PeriodAnchors(yearly_month=6, yearly_monthday=30, yearly_hour=2, yearly_minute=0, yearly_second=0)
         dt = datetime(2024, 3, 15, 10, 0, 0, tzinfo=self.tz)
@@ -2626,7 +2626,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 2, "yearly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_custom_yearly_anchor2b(self):
+    def test_custom_yearly_anchor2b(self) -> None:
         # Custom yearly: snapshots every other year on June 30 at 02:00:00.
         custom = bzfs.PeriodAnchors(yearly_month=6, yearly_monthday=30, yearly_hour=2, yearly_minute=0, yearly_second=0)
         dt = datetime(2025, 3, 15, 10, 0, 0, tzinfo=self.tz)
@@ -2636,7 +2636,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         result = round_datetime_up_to_duration_multiple(dt, 2, "yearly", anchors=custom)
         self.assertEqual(expected, result)
 
-    def test_timezone_preservation(self):
+    def test_timezone_preservation(self) -> None:
         if sys.version_info < (3, 9):
             self.skipTest("ZoneInfo requires python >= 3.9")
         from zoneinfo import ZoneInfo  # requires python >= 3.9
@@ -2662,7 +2662,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
         self.assertEqual(expected.tzinfo, result.tzinfo)
         self.assertEqual(expected.utcoffset(), result.utcoffset())
 
-    def test_monthly_anchor_invalid_day(self):
+    def test_monthly_anchor_invalid_day(self) -> None:
         # Custom monthly: snapshots every month on the 31st
         custom = bzfs.PeriodAnchors(monthly_monthday=31, monthly_hour=12, monthly_minute=0, monthly_second=0)
 
@@ -2679,7 +2679,7 @@ class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
 #############################################################################
 class TestFindMatch(unittest.TestCase):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         condition = lambda arg: arg.startswith("-")  # noqa: E731
 
         lst = ["a", "b", "-c", "d"]
@@ -2797,7 +2797,7 @@ class TestFindMatch(unittest.TestCase):
 #############################################################################
 class TestArgumentParser(unittest.TestCase):
 
-    def test_help(self):
+    def test_help(self) -> None:
         if is_solaris_zfs():
             self.skipTest("FIXME: BlockingIOError: [Errno 11] write could not complete without blocking")
         parser = bzfs.argument_parser()
@@ -2805,25 +2805,25 @@ class TestArgumentParser(unittest.TestCase):
             parser.parse_args(["--help"])
         self.assertEqual(0, e.exception.code)
 
-    def test_version(self):
+    def test_version(self) -> None:
         parser = bzfs.argument_parser()
         with self.assertRaises(SystemExit) as e:
             parser.parse_args(["--version"])
         self.assertEqual(0, e.exception.code)
 
-    def test_missing_datasets(self):
+    def test_missing_datasets(self) -> None:
         parser = bzfs.argument_parser()
         with self.assertRaises(SystemExit) as e:
             parser.parse_args(["--retries=1"])
         self.assertEqual(2, e.exception.code)
 
-    def test_missing_dst_dataset(self):
+    def test_missing_dst_dataset(self) -> None:
         parser = bzfs.argument_parser()
         with self.assertRaises(SystemExit) as e:
             parser.parse_args(["src_dataset"])  # Each SRC_DATASET must have a corresponding DST_DATASET
         self.assertEqual(2, e.exception.code)
 
-    def test_program_must_not_be_empty_string(self):
+    def test_program_must_not_be_empty_string(self) -> None:
         parser = bzfs.argument_parser()
         with self.assertRaises(SystemExit) as e:
             parser.parse_args(["src_dataset", "src_dataset", "--zfs-program="])
@@ -2837,45 +2837,45 @@ class TestDatasetPairsAction(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--input", nargs="+", action=bzfs.DatasetPairsAction)
 
-    def test_direct_value(self):
+    def test_direct_value(self) -> None:
         args = self.parser.parse_args(["--input", "src1", "dst1"])
         self.assertEqual(args.input, [("src1", "dst1")])
 
-    def test_direct_value_without_corresponding_dst(self):
+    def test_direct_value_without_corresponding_dst(self) -> None:
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["--input", "src1"])
 
-    def test_file_input(self):
+    def test_file_input(self) -> None:
         with patch("builtins.open", mock_open(read_data="src1\tdst1\nsrc2\tdst2\n")):
             args = self.parser.parse_args(["--input", "+testfile"])
             self.assertEqual(args.input, [("src1", "dst1"), ("src2", "dst2")])
 
-    def test_file_input_without_trailing_newline(self):
+    def test_file_input_without_trailing_newline(self) -> None:
         with patch("builtins.open", mock_open(read_data="src1\tdst1\nsrc2\tdst2")):
             args = self.parser.parse_args(["--input", "+testfile"])
             self.assertEqual(args.input, [("src1", "dst1"), ("src2", "dst2")])
 
-    def test_mixed_input(self):
+    def test_mixed_input(self) -> None:
         with patch("builtins.open", mock_open(read_data="src1\tdst1\nsrc2\tdst2\n")):
             args = self.parser.parse_args(["--input", "src0", "dst0", "+testfile"])
             self.assertEqual(args.input, [("src0", "dst0"), ("src1", "dst1"), ("src2", "dst2")])
 
-    def test_file_skip_comments_and_empty_lines(self):
+    def test_file_skip_comments_and_empty_lines(self) -> None:
         with patch("builtins.open", mock_open(read_data="\n\n#comment\nsrc1\tdst1\nsrc2\tdst2\n")):
             args = self.parser.parse_args(["--input", "+testfile"])
             self.assertEqual(args.input, [("src1", "dst1"), ("src2", "dst2")])
 
-    def test_file_skip_stripped_empty_lines(self):
+    def test_file_skip_stripped_empty_lines(self) -> None:
         with patch("builtins.open", mock_open(read_data=" \t \nsrc1\tdst1")):
             args = self.parser.parse_args(["--input", "+testfile"])
             self.assertEqual(args.input, [("src1", "dst1")])
 
-    def test_file_missing_tab(self):
+    def test_file_missing_tab(self) -> None:
         with patch("builtins.open", mock_open(read_data="src1\nsrc2")):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(["--input", "+testfile"])
 
-    def test_file_whitespace_only(self):
+    def test_file_whitespace_only(self) -> None:
         with patch("builtins.open", mock_open(read_data=" \tdst1")):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(["--input", "+testfile"])
@@ -2888,7 +2888,7 @@ class TestDatasetPairsAction(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(["--input", "+nonexistentfile"])
 
-    def test_option_not_specified(self):
+    def test_option_not_specified(self) -> None:
         args = self.parser.parse_args([])
         self.assertIsNone(args.input)
 
@@ -2900,31 +2900,31 @@ class TestFileOrLiteralAction(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--input", nargs="+", action=bzfs.FileOrLiteralAction)
 
-    def test_direct_value(self):
+    def test_direct_value(self) -> None:
         args = self.parser.parse_args(["--input", "literalvalue"])
         self.assertEqual(args.input, ["literalvalue"])
 
-    def test_file_input(self):
+    def test_file_input(self) -> None:
         with patch("builtins.open", mock_open(read_data="line 1\nline 2  \n")):
             args = self.parser.parse_args(["--input", "+testfile"])
             self.assertEqual(args.input, ["line 1", "line 2  "])
 
-    def test_mixed_input(self):
+    def test_mixed_input(self) -> None:
         with patch("builtins.open", mock_open(read_data="line 1\nline 2")):
             args = self.parser.parse_args(["--input", "literalvalue", "+testfile"])
             self.assertEqual(args.input, ["literalvalue", "line 1", "line 2"])
 
-    def test_skip_comments_and_empty_lines(self):
+    def test_skip_comments_and_empty_lines(self) -> None:
         with patch("builtins.open", mock_open(read_data="\n\n#comment\nline 1\n\n\nline 2\n")):
             args = self.parser.parse_args(["--input", "+testfile"])
             self.assertEqual(args.input, ["line 1", "line 2"])
 
-    def test_file_not_found(self):
+    def test_file_not_found(self) -> None:
         with patch("builtins.open", side_effect=FileNotFoundError):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(["--input", "+nonexistentfile"])
 
-    def test_option_not_specified(self):
+    def test_option_not_specified(self) -> None:
         args = self.parser.parse_args([])
         self.assertIsNone(args.input)
 
@@ -2936,11 +2936,11 @@ class TestNewSnapshotFilterGroupAction(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--new-snapshot-filter-group", action=bzfs.NewSnapshotFilterGroupAction, nargs=0)
 
-    def test_basic0(self):
+    def test_basic0(self) -> None:
         args = self.parser.parse_args(["--new-snapshot-filter-group"])
         self.assertListEqual([[]], getattr(args, bzfs.snapshot_filters_var))
 
-    def test_basic1(self):
+    def test_basic1(self) -> None:
         args = self.parser.parse_args(["--new-snapshot-filter-group", "--new-snapshot-filter-group"])
         self.assertListEqual([[]], getattr(args, bzfs.snapshot_filters_var))
 
@@ -2957,14 +2957,14 @@ class TestTimeRangeAction(unittest.TestCase):
     def parse_timestamp(self, arg: str) -> argparse.Namespace:
         return self.parser.parse_args(["--time-n-ranks", arg + "..anytime"])
 
-    def test_parse_unix_time(self):  # Test Unix time in integer seconds
+    def test_parse_unix_time(self) -> None:  # Test Unix time in integer seconds
         args = self.parse_timestamp("1696510080")
         self.assertEqual(args.time_n_ranks[0][0], 1696510080)
 
         args = self.parse_timestamp("0")
         self.assertEqual(args.time_n_ranks[0][0], 0)
 
-    def test_valid_durations(self):
+    def test_valid_durations(self) -> None:
         args = self.parse_duration("5millis")
         self.assertEqual(args.time_n_ranks[0][0], timedelta(milliseconds=5))
 
@@ -3015,7 +3015,7 @@ class TestTimeRangeAction(unittest.TestCase):
         args = self.parse_duration("5secs")
         self.assertEqual(args.time_n_ranks[0][0], timedelta(seconds=5))
 
-    def test_invalid_time_spec(self):
+    def test_invalid_time_spec(self) -> None:
         with self.assertRaises(SystemExit):
             self.parse_duration("")  # Empty string
 
@@ -3043,7 +3043,7 @@ class TestTimeRangeAction(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["--time-n-ranks", "60_mins_ago"])  # Missing ..
 
-    def test_parse_datetime(self):
+    def test_parse_datetime(self) -> None:
         # Test ISO 8601 datetime strings without timezone
         args = self.parse_timestamp("2024-01-01")
         self.assertEqual(args.time_n_ranks[0][0], int(datetime.fromisoformat("2024-01-01").timestamp()))
@@ -3055,7 +3055,7 @@ class TestTimeRangeAction(unittest.TestCase):
         self.assertEqual(args.time_n_ranks[0][0], int(datetime.fromisoformat("2024-10-05T14:48:55").timestamp()))
         self.assertNotEqual(args.time_n_ranks[0][0], int(datetime.fromisoformat("2024-10-05T14:48:01").timestamp()))
 
-    def test_parse_datetime_with_timezone(self):
+    def test_parse_datetime_with_timezone(self) -> None:
         tz_py_version = (3, 11)
         if sys.version_info < tz_py_version:
             self.skipTest("Timezone support in datetime.fromisoformat() requires python >= 3.11")
@@ -3073,7 +3073,7 @@ class TestTimeRangeAction(unittest.TestCase):
         args = self.parse_timestamp("2024-10-05T14:48:55+02:00")
         self.assertEqual(args.time_n_ranks[0][0], int(datetime.fromisoformat("2024-10-05T14:48:55+02:00").timestamp()))
 
-    def test_get_include_snapshot_times(self):
+    def test_get_include_snapshot_times(self) -> None:
         times_and_ranks_opt = "--include-snapshot-times-and-ranks="
         wildcards = ["*", "anytime"]
 
@@ -3128,7 +3128,7 @@ class TestTimeRangeAction(unittest.TestCase):
             self.assertEqual(0, timerange[0])
             self.assertEqual(int(datetime.fromisoformat("2024-01-01").timestamp()), cast(int, timerange[1]))
 
-    def test_filter_snapshots_by_times(self):
+    def test_filter_snapshots_by_times(self) -> None:
         lst1 = ["\t" + snapshot for snapshot in ["d@0", "d#1", "d@2", "d@3"]]
         self.assertListEqual(["\td#1"], self.filter_snapshots_by_times_and_rank1(lst1, "0..0"))
         self.assertListEqual(["\td#1"], self.filter_snapshots_by_times_and_rank1(lst1, "notime"))
@@ -3173,11 +3173,11 @@ class TestRankRangeAction(unittest.TestCase):
     def parse_args(self, arg: str) -> argparse.Namespace:
         return self.parser.parse_args(["--ranks", "0..0", arg])
 
-    def test_valid_ranks(self):
+    def test_valid_ranks(self) -> None:
         self.assertEqual((("latest", 0, False), ("latest", 2, True)), self.parse_args("latest0..latest2%").ranks[1])
         self.assertEqual((("oldest", 5, True), ("oldest", 9, True)), self.parse_args("oldest5%..oldest9%").ranks[1])
 
-    def test_invalid_ranks(self):
+    def test_invalid_ranks(self) -> None:
         with self.assertRaises(SystemExit):
             self.parse_args("all except oldest0..all except oldest10")  # Range partitioning not yet implemented
 
@@ -3211,7 +3211,7 @@ class TestRankRangeAction(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.parse_args("oldest1..xxxx100%")  # unknown param
 
-    def test_ambigous_rankrange(self):
+    def test_ambigous_rankrange(self) -> None:
         with self.assertRaises(SystemExit):
             self.parse_args("latest0..oldest0")
         with self.assertRaises(SystemExit):
@@ -3226,7 +3226,7 @@ class TestRankRangeAction(unittest.TestCase):
     def filter_snapshots_by_rank(self, snapshots: List[str], ranks: List[str], timerange: str = "0..0") -> List[str]:
         return filter_snapshots_by_times_and_rank(snapshots, timerange=timerange, ranks=ranks)
 
-    def test_filter_snapshots_by_rank(self):
+    def test_filter_snapshots_by_rank(self) -> None:
         lst1 = ["\t" + snapshot for snapshot in ["d@0", "d@1", "d@2", "d@3"]]
         self.assertListEqual([], self.filter_snapshots_by_rank(lst1, ["latest0..latest0"]))
         self.assertListEqual(["\td@3"], self.filter_snapshots_by_rank(lst1, ["latest0..latest1"]))
@@ -3293,7 +3293,7 @@ class TestRankRangeAction(unittest.TestCase):
         self.assertListEqual(["\td@0"], self.filter_snapshots_by_rank(lst1, ["oldest0..oldest1"]))
         self.assertListEqual(["\td@0", "\td@1"], self.filter_snapshots_by_rank(lst2, ["latest100%..latest1"]))
 
-    def test_filter_snapshots_by_rank_with_bookmarks(self):
+    def test_filter_snapshots_by_rank_with_bookmarks(self) -> None:
         lst1 = ["\t" + snapshot for snapshot in ["d@0", "d#1", "d@2", "d@3"]]
         self.assertListEqual(["\td#1"], self.filter_snapshots_by_rank(lst1, ["oldest0..oldest0"]))
         self.assertListEqual(["\td@0", "\td#1"], self.filter_snapshots_by_rank(lst1, ["oldest0..oldest1"]))
@@ -3303,7 +3303,7 @@ class TestRankRangeAction(unittest.TestCase):
         self.assertListEqual(lst1, self.filter_snapshots_by_rank(lst1, ["oldest0..oldest5"]))
         self.assertListEqual(["\td@0", "\td#1", "\td@2"], self.filter_snapshots_by_rank(lst1, ["latest1..latest100%"]))
 
-    def test_filter_snapshots_by_rank_with_chain(self):
+    def test_filter_snapshots_by_rank_with_chain(self) -> None:
         lst1 = ["\t" + snapshot for snapshot in ["d@0", "d#1", "d@2", "d@3"]]
         results = self.filter_snapshots_by_rank(lst1, ["latest1..latest100%", "latest1..latest100%"])
         self.assertListEqual(["\td@0", "\td#1"], results)
@@ -3311,7 +3311,7 @@ class TestRankRangeAction(unittest.TestCase):
         results = self.filter_snapshots_by_rank(lst1, ["latest1..latest100%", "oldest1..oldest100%"])
         self.assertListEqual(["\td#1", "\td@2"], results)
 
-    def test_filter_snapshots_by_rank_with_times(self):
+    def test_filter_snapshots_by_rank_with_times(self) -> None:
         lst1 = ["\t" + snapshot for snapshot in ["d@0", "d#1", "d@2", "d@3"]]
         self.assertListEqual(["\td@0", "\td#1"], self.filter_snapshots_by_rank(lst1, ["oldest 1"], timerange="0..0"))
         self.assertListEqual(["\td@0", "\td#1"], self.filter_snapshots_by_rank(lst1, ["oldest 1"], timerange="notime"))
@@ -3331,7 +3331,7 @@ class TestRankRangeAction(unittest.TestCase):
         args = argparser_parse_args(args=["src", "dst", *cli])
         return bzfs.Params(args).snapshot_filters[0]
 
-    def test_merge_adjacent_snapshot_regexes_and_filters0(self):
+    def test_merge_adjacent_snapshot_regexes_and_filters0(self) -> None:
         ranks = "--include-snapshot-times-and-ranks"
         cli = [ranks, "0..1", "oldest 50%", ranks, "0..0", "oldest 10%"]
         ranks_filter = self.get_snapshot_filters(cli)
@@ -3340,7 +3340,7 @@ class TestRankRangeAction(unittest.TestCase):
         self.assertEqual((0, 0), ranks_filter[1].timerange)
         self.assertEqual([(("oldest", 0, False), ("oldest", 10, True))], ranks_filter[1].options)
 
-    def test_merge_adjacent_snapshot_regexes_and_filters1(self):
+    def test_merge_adjacent_snapshot_regexes_and_filters1(self) -> None:
         ranks = "--include-snapshot-times-and-ranks"
         cli = [ranks, "0..0", "oldest 50%", ranks, "0..0", "oldest 10%"]
         ranks_filter = self.get_snapshot_filters(cli)[0]
@@ -3353,7 +3353,7 @@ class TestRankRangeAction(unittest.TestCase):
             ranks_filter.options,
         )
 
-    def test_merge_adjacent_snapshot_regexes_and_filters2(self):
+    def test_merge_adjacent_snapshot_regexes_and_filters2(self) -> None:
         ranks = "--include-snapshot-times-and-ranks"
         cli = [ranks, "0..0", "oldest 50%", ranks, "0..0", "oldest 10%", ranks, "0..0", "oldest 20%"]
         ranks_filter = self.get_snapshot_filters(cli)[0]
@@ -3367,7 +3367,7 @@ class TestRankRangeAction(unittest.TestCase):
             ranks_filter.options,
         )
 
-    def test_merge_adjacent_snapshot_regexes_and_filters3(self):
+    def test_merge_adjacent_snapshot_regexes_and_filters3(self) -> None:
         include = "--include-snapshot-regex"
         exclude = "--exclude-snapshot-regex"
         times = "--include-snapshot-times-and-ranks"
@@ -3378,7 +3378,7 @@ class TestRankRangeAction(unittest.TestCase):
         self.assertEqual(bzfs.snapshot_regex_filter_name, regex_filter.name)
         self.assertEqual((["w", "m"], ["f", "d", "h"]), regex_filter.options)
 
-    def test_merge_adjacent_snapshot_regexes_doesnt_merge_across_groups(self):
+    def test_merge_adjacent_snapshot_regexes_doesnt_merge_across_groups(self) -> None:
         include = "--include-snapshot-regex"
         exclude = "--exclude-snapshot-regex"
         ranks = "--include-snapshot-times-and-ranks"
@@ -3392,7 +3392,7 @@ class TestRankRangeAction(unittest.TestCase):
         self.assertEqual(bzfs.snapshot_regex_filter_name, regex_filter2.name)
         self.assertEqual(([".*m"], []), regex_filter2.options)
 
-    def test_reorder_snapshot_times_simple(self):
+    def test_reorder_snapshot_times_simple(self) -> None:
         include = "--include-snapshot-regex"
         times = "--include-snapshot-times-and-ranks"
         cli = [include, ".*daily", times, "0..9"]
@@ -3402,7 +3402,7 @@ class TestRankRangeAction(unittest.TestCase):
         self.assertEqual(bzfs.snapshot_regex_filter_name, regex_filter.name)
         self.assertEqual(([], [".*daily"]), regex_filter.options)
 
-    def test_reorder_snapshot_times_complex(self):
+    def test_reorder_snapshot_times_complex(self) -> None:
         include = "--include-snapshot-regex"
         exclude = "--exclude-snapshot-regex"
         times = "--include-snapshot-times-and-ranks"
@@ -3425,7 +3425,7 @@ class TestLogConfigVariablesAction(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--log-config-var", nargs="+", action=bzfs.LogConfigVariablesAction)
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         args = self.parser.parse_args(["--log-config-var", "name1:val1", "name2:val2"])
         self.assertEqual(args.log_config_var, ["name1:val1", "name2:val2"])
 
@@ -3441,31 +3441,31 @@ class TestSafeFileNameAction(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("filename", action=bzfs.SafeFileNameAction)
 
-    def test_safe_filename(self):
+    def test_safe_filename(self) -> None:
         args = self.parser.parse_args(["file1.txt"])
         self.assertEqual(args.filename, "file1.txt")
 
-    def test_empty_filename(self):
+    def test_empty_filename(self) -> None:
         args = self.parser.parse_args([""])
         self.assertEqual(args.filename, "")
 
-    def test_filename_in_subdirectory(self):
+    def test_filename_in_subdirectory(self) -> None:
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["subdir/safe_file.txt"])
 
-    def test_unsafe_filename_with_parent_directory_reference(self):
+    def test_unsafe_filename_with_parent_directory_reference(self) -> None:
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["../escape.txt"])
 
-    def test_unsafe_filename_with_absolute_path(self):
+    def test_unsafe_filename_with_absolute_path(self) -> None:
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["/unsafe_file.txt"])
 
-    def test_unsafe_nested_parent_directory(self):
+    def test_unsafe_nested_parent_directory(self) -> None:
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["../../another_escape.txt"])
 
-    def test_filename_with_single_dot_slash(self):
+    def test_filename_with_single_dot_slash(self) -> None:
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["./file.txt"])
 
@@ -3473,123 +3473,123 @@ class TestSafeFileNameAction(unittest.TestCase):
 #############################################################################
 class TestCheckRange(unittest.TestCase):
 
-    def test_valid_range_min_max(self):
+    def test_valid_range_min_max(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange, min=0, max=100)
         args = parser.parse_args(["--age", "50"])
         self.assertEqual(args.age, 50)
 
-    def test_valid_range_inf_sup(self):
+    def test_valid_range_inf_sup(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange, inf=0, sup=100)
         args = parser.parse_args(["--age", "50"])
         self.assertEqual(args.age, 50)
 
-    def test_invalid_range_min_max(self):
+    def test_invalid_range_min_max(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange, min=0, max=100)
         with self.assertRaises(SystemExit):
             parser.parse_args(["--age", "-1"])
 
-    def test_invalid_range_inf_sup(self):
+    def test_invalid_range_inf_sup(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange, inf=0, sup=100)
         with self.assertRaises(SystemExit):
             parser.parse_args(["--age", "101"])
 
-    def test_invalid_combination_min_inf(self):
+    def test_invalid_combination_min_inf(self) -> None:
         with self.assertRaises(ValueError):
             parser = argparse.ArgumentParser()
             parser.add_argument("--age", type=int, action=bzfs.CheckRange, min=0, inf=100)
 
-    def test_invalid_combination_max_sup(self):
+    def test_invalid_combination_max_sup(self) -> None:
         with self.assertRaises(ValueError):
             parser = argparse.ArgumentParser()
             parser.add_argument("--age", type=int, action=bzfs.CheckRange, max=0, sup=100)
 
-    def test_valid_float_range_min_max(self):
+    def test_valid_float_range_min_max(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=float, action=bzfs.CheckRange, min=0.0, max=100.0)
         args = parser.parse_args(["--age", "50.5"])
         self.assertEqual(args.age, 50.5)
 
-    def test_invalid_float_range_min_max(self):
+    def test_invalid_float_range_min_max(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=float, action=bzfs.CheckRange, min=0.0, max=100.0)
         with self.assertRaises(SystemExit):
             parser.parse_args(["--age", "-0.1"])
 
-    def test_valid_edge_case_min(self):
+    def test_valid_edge_case_min(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=float, action=bzfs.CheckRange, min=0.0, max=100.0)
         args = parser.parse_args(["--age", "0.0"])
         self.assertEqual(args.age, 0.0)
 
-    def test_valid_edge_case_max(self):
+    def test_valid_edge_case_max(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=float, action=bzfs.CheckRange, min=0.0, max=100.0)
         args = parser.parse_args(["--age", "100.0"])
         self.assertEqual(args.age, 100.0)
 
-    def test_invalid_edge_case_sup(self):
+    def test_invalid_edge_case_sup(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=float, action=bzfs.CheckRange, inf=0.0, sup=100.0)
         with self.assertRaises(SystemExit):
             parser.parse_args(["--age", "100.0"])
 
-    def test_invalid_edge_case_inf(self):
+    def test_invalid_edge_case_inf(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=float, action=bzfs.CheckRange, inf=0.0, sup=100.0)
         with self.assertRaises(SystemExit):
             parser.parse_args(["--age", "0.0"])
 
-    def test_no_range_constraints(self):
+    def test_no_range_constraints(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange)
         args = parser.parse_args(["--age", "150"])
         self.assertEqual(args.age, 150)
 
-    def test_no_range_constraints_float(self):
+    def test_no_range_constraints_float(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=float, action=bzfs.CheckRange)
         args = parser.parse_args(["--age", "150.5"])
         self.assertEqual(args.age, 150.5)
 
-    def test_very_large_value(self):
+    def test_very_large_value(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange, max=10**18)
         args = parser.parse_args(["--age", "999999999999999999"])
         self.assertEqual(args.age, 999999999999999999)
 
-    def test_very_small_value(self):
+    def test_very_small_value(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange, min=-(10**18))
         args = parser.parse_args(["--age", "-999999999999999999"])
         self.assertEqual(args.age, -999999999999999999)
 
-    def test_default_interval(self):
+    def test_default_interval(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange)
         action = bzfs.CheckRange(option_strings=["--age"], dest="age")
         self.assertEqual(action.interval(), "valid range: (-infinity, +infinity)")
 
-    def test_interval_with_inf_sup(self):
+    def test_interval_with_inf_sup(self) -> None:
         action = bzfs.CheckRange(option_strings=["--age"], dest="age", inf=0, sup=100)
         self.assertEqual(action.interval(), "valid range: (0, 100)")
 
-    def test_interval_with_min_max(self):
+    def test_interval_with_min_max(self) -> None:
         action = bzfs.CheckRange(option_strings=["--age"], dest="age", min=0, max=100)
         self.assertEqual(action.interval(), "valid range: [0, 100]")
 
-    def test_interval_with_min(self):
+    def test_interval_with_min(self) -> None:
         action = bzfs.CheckRange(option_strings=["--age"], dest="age", min=0)
         self.assertEqual(action.interval(), "valid range: [0, +infinity)")
 
-    def test_interval_with_max(self):
+    def test_interval_with_max(self) -> None:
         action = bzfs.CheckRange(option_strings=["--age"], dest="age", max=100)
         self.assertEqual(action.interval(), "valid range: (-infinity, 100]")
 
-    def test_call_without_range_constraints(self):
+    def test_call_without_range_constraints(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--age", type=int, action=bzfs.CheckRange)
         args = parser.parse_args(["--age", "50"])
@@ -3599,7 +3599,7 @@ class TestCheckRange(unittest.TestCase):
 #############################################################################
 class TestCheckPercentRange(unittest.TestCase):
 
-    def test_valid_range_min(self):
+    def test_valid_range_min(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--threads", action=bzfs.CheckPercentRange, min=1)
         args = parser.parse_args(["--threads", "1"])
@@ -3607,7 +3607,7 @@ class TestCheckPercentRange(unittest.TestCase):
         self.assertEqual(threads, 1.0)
         self.assertFalse(is_percent)
 
-    def test_valid_range_percent(self):
+    def test_valid_range_percent(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--threads", action=bzfs.CheckPercentRange, min=1)
         args = parser.parse_args(["--threads", "5.2%"])
@@ -3615,7 +3615,7 @@ class TestCheckPercentRange(unittest.TestCase):
         self.assertEqual(threads, 5.2)
         self.assertTrue(is_percent)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument("--threads", action=bzfs.CheckPercentRange, min=1)
         with self.assertRaises(SystemExit):
@@ -3636,7 +3636,7 @@ class TestPythonVersionCheck(unittest.TestCase):
 
     @patch("sys.exit")
     @patch("sys.version_info", new=(3, 6))
-    def test_version_below_3_8(self, mock_exit):
+    def test_version_below_3_8(self, mock_exit) -> None:
         with patch("sys.stderr"):
             import importlib
             from bzfs_main import bzfs
@@ -3646,7 +3646,7 @@ class TestPythonVersionCheck(unittest.TestCase):
 
     @patch("sys.exit")
     @patch("sys.version_info", new=(3, 8))
-    def test_version_3_8_or_higher(self, mock_exit):
+    def test_version_3_8_or_higher(self, mock_exit) -> None:
         import importlib
         from bzfs_main import bzfs
 
@@ -3684,7 +3684,7 @@ class TestConnectionPool(unittest.TestCase):
         cpool.return_connection(conn)
         dpool.return_connection(donn)
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         counter1a = itertools.count()
         counter2a = itertools.count()
         counter1b = itertools.count()
@@ -3736,7 +3736,7 @@ class TestConnectionPool(unittest.TestCase):
         cpool.shutdown("bar")
         cpool.return_connection(conn3)
 
-    def test_multiple_TCP_connections(self):
+    def test_multiple_TCP_connections(self) -> None:
         capacity = 2
         cpool = bzfs.ConnectionPool(self.remote, capacity)
 
@@ -3804,7 +3804,7 @@ class TestConnectionPool(unittest.TestCase):
 
         cpool.shutdown("foo")
 
-    def test_pools(self):
+    def test_pools(self) -> None:
         with self.assertRaises(AssertionError):
             bzfs.ConnectionPools(self.dst, {"shared": 0})
 
@@ -3818,7 +3818,7 @@ class TestConnectionPool(unittest.TestCase):
         pools.pool("shared").get_connection()
         pools.shutdown("foo")
 
-    def test_return_sequence(self):
+    def test_return_sequence(self) -> None:
         maxsessions = 10
         items = 10
         for j in range(0, 3):
@@ -3832,7 +3832,7 @@ class TestConnectionPool(unittest.TestCase):
                 self.return_connection(cpool, conn, dpool, donn)
             print(f"cpool: {cpool}")
 
-    def test_long_random_walk(self):
+    def test_long_random_walk(self) -> None:
         log = logging.getLogger(bzfs.__name__)
         # loglevel = logging.DEBUG
         loglevel = log_trace
@@ -3924,37 +3924,37 @@ class SlowButCorrectConnectionPool(bzfs.ConnectionPool):  # validate a better im
 #############################################################################
 class TestIncrementalSendSteps(unittest.TestCase):
 
-    def test_basic1(self):
+    def test_basic1(self) -> None:
         input_snapshots = ["d1", "h1", "d2", "d3", "d4"]
         expected_results = ["d1", "d2", "d3", "d4"]
         self.validate_incremental_send_steps(input_snapshots, expected_results)
 
-    def test_basic2(self):
+    def test_basic2(self) -> None:
         input_snapshots = ["d1", "d2", "h1", "d3", "d4"]
         expected_results = ["d1", "d2", "d3", "d4"]
         self.validate_incremental_send_steps(input_snapshots, expected_results)
 
-    def test_basic3(self):
+    def test_basic3(self) -> None:
         input_snapshots: List[str] = ["h0", "h1", "d1", "d2", "h2", "d3", "d4"]
         expected_results: List[str] = ["d1", "d2", "d3", "d4"]
         self.validate_incremental_send_steps(input_snapshots, expected_results)
 
-    def test_basic4(self):
+    def test_basic4(self) -> None:
         input_snapshots: List[str] = ["d1"]
         expected_results: List[str] = ["d1"]
         self.validate_incremental_send_steps(input_snapshots, expected_results)
 
-    def test_basic5(self):
+    def test_basic5(self) -> None:
         input_snapshots: List[str] = []
         expected_results: List[str] = []
         self.validate_incremental_send_steps(input_snapshots, expected_results)
 
-    def test_validate_snapshot_series_excluding_hourlies_with_permutations(self):
+    def test_validate_snapshot_series_excluding_hourlies_with_permutations(self) -> None:
         for i, testcase in enumerate(self.permute_snapshot_series()):
             with stop_on_failure_subtest(i=i):
                 self.validate_incremental_send_steps(testcase[None], testcase["d"])
 
-    def test_send_step_to_str(self):
+    def test_send_step_to_str(self) -> None:
         bzfs.Job().send_step_to_str(("-I", "d@s1", "d@s3"))
 
     def permute_snapshot_series(self, max_length: int = 9) -> List[DefaultDict[Optional[str], List[str]]]:
@@ -4073,7 +4073,7 @@ class TestSmallPriorityQueue(unittest.TestCase):
         self.pq: bzfs.SmallPriorityQueue[int] = bzfs.SmallPriorityQueue()
         self.pq_reverse: bzfs.SmallPriorityQueue[int] = bzfs.SmallPriorityQueue(reverse=True)
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         self.assertEqual(0, len(self.pq))
         self.assertTrue(len(str(self.pq)) > 0)
         self.pq.push(2)
@@ -4086,7 +4086,7 @@ class TestSmallPriorityQueue(unittest.TestCase):
         self.pq.clear()
         self.assertEqual(len(self.pq), 0)
 
-    def test_push_and_pop(self):
+    def test_push_and_pop(self) -> None:
         self.pq.push(3)
         self.pq.push(1)
         self.pq.push(2)
@@ -4094,11 +4094,11 @@ class TestSmallPriorityQueue(unittest.TestCase):
         self.assertEqual(self.pq.pop(), 1)
         self.assertEqual(self.pq._lst, [2, 3])
 
-    def test_pop_empty(self):
+    def test_pop_empty(self) -> None:
         with self.assertRaises(IndexError):  # Generic IndexError from list.pop()
             self.pq.pop()
 
-    def test_remove(self):
+    def test_remove(self) -> None:
         self.pq.push(3)
         self.pq.push(1)
         self.pq.push(2)
@@ -4108,7 +4108,7 @@ class TestSmallPriorityQueue(unittest.TestCase):
         self.assertTrue(self.pq.remove(1))
         self.assertEqual(self.pq._lst, [3])
 
-    def test_remove_nonexistent_element(self):
+    def test_remove_nonexistent_element(self) -> None:
         self.pq.push(1)
         self.pq.push(3)
         self.pq.push(2)
@@ -4116,7 +4116,7 @@ class TestSmallPriorityQueue(unittest.TestCase):
         # Attempt to remove an element that doesn't exist (should raise IndexError)
         self.assertFalse(self.pq.remove(4))
 
-    def test_peek(self):
+    def test_peek(self) -> None:
         self.pq.push(3)
         self.pq.push(1)
         self.pq.push(2)
@@ -4128,21 +4128,21 @@ class TestSmallPriorityQueue(unittest.TestCase):
         self.assertEqual(self.pq_reverse.peek(), 3)
         self.assertEqual(self.pq_reverse._lst, [1, 2, 3])
 
-    def test_peek_empty(self):
+    def test_peek_empty(self) -> None:
         with self.assertRaises(IndexError):  # Generic IndexError from list indexing
             self.pq.peek()
 
         with self.assertRaises(IndexError):  # Generic IndexError from list indexing
             self.pq_reverse.peek()
 
-    def test_reverse_order(self):
+    def test_reverse_order(self) -> None:
         self.pq_reverse.push(1)
         self.pq_reverse.push(3)
         self.pq_reverse.push(2)
         self.assertEqual(self.pq_reverse.pop(), 3)
         self.assertEqual(self.pq_reverse._lst, [1, 2])
 
-    def test_iter(self):
+    def test_iter(self) -> None:
         self.pq.push(3)
         self.pq.push(1)
         self.pq.push(2)
@@ -4154,7 +4154,7 @@ class TestSmallPriorityQueue(unittest.TestCase):
         self.assertListEqual([3, 2, 1], list(iter(self.pq_reverse)))
         self.assertEqual("[3, 2, 1]", str(self.pq_reverse))
 
-    def test_duplicates(self):
+    def test_duplicates(self) -> None:
         self.pq.push(2)
         self.pq.push(2)
         self.pq.push(1)
@@ -4173,7 +4173,7 @@ class TestSmallPriorityQueue(unittest.TestCase):
         self.assertEqual(self.pq.pop(), 2)
         self.assertEqual(len(self.pq), 0)
 
-    def test_reverse_with_duplicates(self):
+    def test_reverse_with_duplicates(self) -> None:
         self.pq_reverse.push(2)
         self.pq_reverse.push(2)
         self.pq_reverse.push(3)
@@ -4197,7 +4197,7 @@ class TestSmallPriorityQueue(unittest.TestCase):
 
 #############################################################################
 class TestSynchronizedBool(unittest.TestCase):
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         b = bzfs.SynchronizedBool(True)
         self.assertTrue(b.value)
 
@@ -4207,32 +4207,32 @@ class TestSynchronizedBool(unittest.TestCase):
         with self.assertRaises(AssertionError):
             bzfs.SynchronizedBool(cast(Any, "not_a_bool"))
 
-    def test_value_property(self):
+    def test_value_property(self) -> None:
         b = bzfs.SynchronizedBool(True)
         self.assertTrue(b.value)
 
         b.value = False
         self.assertFalse(b.value)
 
-    def test_loop(self):
+    def test_loop(self) -> None:
         b = bzfs.SynchronizedBool(False)
         for _ in range(3):
             b.value = not b.value
         self.assertIsInstance(b.value, bool)
 
-    def test_bool_conversion(self):
+    def test_bool_conversion(self) -> None:
         b = bzfs.SynchronizedBool(True)
         self.assertTrue(bool(b))
 
         b.value = False
         self.assertFalse(bool(b))
 
-    def test_get_and_set(self):
+    def test_get_and_set(self) -> None:
         b = bzfs.SynchronizedBool(True)
         self.assertTrue(b.get_and_set(False))
         self.assertFalse(b.value)
 
-    def test_compare_and_set(self):
+    def test_compare_and_set(self) -> None:
         b = bzfs.SynchronizedBool(True)
         self.assertTrue(b.compare_and_set(True, False))
         self.assertFalse(b.value)
@@ -4241,7 +4241,7 @@ class TestSynchronizedBool(unittest.TestCase):
         self.assertFalse(b.compare_and_set(False, False))
         self.assertTrue(b.value)
 
-    def test_str_and_repr(self):
+    def test_str_and_repr(self) -> None:
         b = bzfs.SynchronizedBool(True)
         self.assertEqual(str(b), "True")
         self.assertEqual(repr(b), "True")
@@ -4256,51 +4256,51 @@ class TestSynchronizedDict(unittest.TestCase):
     def setUp(self) -> None:
         self.sync_dict = bzfs.SynchronizedDict({"a": 1, "b": 2, "c": 3})
 
-    def test_getitem(self):
+    def test_getitem(self) -> None:
         self.assertEqual(self.sync_dict["a"], 1)
         self.assertEqual(self.sync_dict["b"], 2)
 
-    def test_setitem(self):
+    def test_setitem(self) -> None:
         self.sync_dict["d"] = 4
         self.assertEqual(self.sync_dict["d"], 4)
 
-    def test_delitem(self):
+    def test_delitem(self) -> None:
         del self.sync_dict["a"]
         self.assertNotIn("a", cast(Container[str], self.sync_dict))
 
-    def test_contains(self):
+    def test_contains(self) -> None:
         self.assertTrue("a" in self.sync_dict)
         self.assertFalse("z" in self.sync_dict)
 
-    def test_len(self):
+    def test_len(self) -> None:
         self.assertEqual(len(self.sync_dict), 3)
         del self.sync_dict["a"]
         self.assertEqual(len(self.sync_dict), 2)
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         self.assertEqual(repr(self.sync_dict), repr({"a": 1, "b": 2, "c": 3}))
 
-    def test_str(self):
+    def test_str(self) -> None:
         self.assertEqual(str(self.sync_dict), str({"a": 1, "b": 2, "c": 3}))
 
-    def test_get(self):
+    def test_get(self) -> None:
         self.assertEqual(self.sync_dict.get("a"), 1)
         self.assertEqual(self.sync_dict.get("z", 42), 42)
 
-    def test_pop(self):
+    def test_pop(self) -> None:
         value = self.sync_dict.pop("b")
         self.assertEqual(value, 2)
         self.assertNotIn("b", cast(Container[str], self.sync_dict))
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         self.sync_dict.clear()
         self.assertEqual(len(self.sync_dict), 0)
 
-    def test_items(self):
+    def test_items(self) -> None:
         items = self.sync_dict.items()
         self.assertEqual(set(items), {("a", 1), ("b", 2), ("c", 3)})
 
-    def test_loop(self):
+    def test_loop(self) -> None:
         self.sync_dict["key"] = 1
         self.assertIn("key", cast(Container[str], self.sync_dict))
 
@@ -4371,31 +4371,31 @@ class TestItrSSHCmdParallel(unittest.TestCase):
     def tearDown(self) -> None:
         bzfs.reset_logger()
 
-    def test_ordered_with_max_batch_items_2(self):
+    def test_ordered_with_max_batch_items_2(self) -> None:
         results = list(
             self.job.itr_ssh_cmd_parallel(self.r, self.cmd_args_list_2, dummy_fn_ordered, max_batch_items=2, ordered=True)
         )
         self.assertEqual(results, self.expected_ordered_2)
 
-    def test_unordered_with_max_batch_items_2(self):
+    def test_unordered_with_max_batch_items_2(self) -> None:
         results = list(
             self.job.itr_ssh_cmd_parallel(self.r, self.cmd_args_list_2, dummy_fn_unordered, max_batch_items=2, ordered=False)
         )
         self.assertEqual(sorted(results), sorted(self.expected_ordered_2))
 
-    def test_ordered_with_max_batch_items_3(self):
+    def test_ordered_with_max_batch_items_3(self) -> None:
         results = list(
             self.job.itr_ssh_cmd_parallel(self.r, self.cmd_args_list_3, dummy_fn_ordered, max_batch_items=3, ordered=True)
         )
         self.assertEqual(results, self.expected_ordered_3)
 
-    def test_unordered_with_max_batch_items_3(self):
+    def test_unordered_with_max_batch_items_3(self) -> None:
         results = list(
             self.job.itr_ssh_cmd_parallel(self.r, self.cmd_args_list_3, dummy_fn_unordered, max_batch_items=3, ordered=False)
         )
         self.assertEqual(sorted(results), sorted(self.expected_ordered_3))
 
-    def test_exception_propagation_ordered(self):
+    def test_exception_propagation_ordered(self) -> None:
         cmd_args_list = [(["ok"], ["a1", "a2"]), (["fail"], ["b1", "b2"])]
         gen = self.job.itr_ssh_cmd_parallel(self.r, cmd_args_list, dummy_fn_raise, max_batch_items=2, ordered=True)
         result = next(gen)
@@ -4404,7 +4404,7 @@ class TestItrSSHCmdParallel(unittest.TestCase):
             next(gen)
         self.assertEqual(str(context.exception), "Intentional failure")
 
-    def test_exception_propagation_unordered(self):
+    def test_exception_propagation_unordered(self) -> None:
         cmd_args_list = [(["ok"], ["a1", "a2"]), (["fail"], ["b1", "b2"])]
         gen = self.job.itr_ssh_cmd_parallel(self.r, cmd_args_list, dummy_fn_raise, max_batch_items=2, ordered=False)
         caught_exception = False
@@ -4417,7 +4417,7 @@ class TestItrSSHCmdParallel(unittest.TestCase):
             self.assertEqual(str(e), "Intentional failure")
         self.assertTrue(caught_exception, "Expected exception was not raised in unordered mode..")
 
-    def test_unordered_thread_scheduling(self):
+    def test_unordered_thread_scheduling(self) -> None:
         cmd_args_list = [
             (["zfslist1"], ["a1"]),
             (["zfslist2"], ["b1"]),
@@ -4433,15 +4433,15 @@ class TestItrSSHCmdParallel(unittest.TestCase):
         )
         self.assertEqual(sorted(unordered_results), sorted(expected_ordered))
 
-    def test_empty_cmd_args_list_ordered(self):
+    def test_empty_cmd_args_list_ordered(self) -> None:
         results = list(self.job.itr_ssh_cmd_parallel(self.r, [], dummy_fn_ordered, max_batch_items=2, ordered=True))
         self.assertEqual(results, [])
 
-    def test_empty_cmd_args_list_unordered(self):
+    def test_empty_cmd_args_list_unordered(self) -> None:
         results = list(self.job.itr_ssh_cmd_parallel(self.r, [], dummy_fn_ordered, max_batch_items=2, ordered=False))
         self.assertEqual(results, [])
 
-    def test_cmd_with_empty_arguments_ordered(self):
+    def test_cmd_with_empty_arguments_ordered(self) -> None:
         cmd_args_list = [(["zfslist1"], []), (["zfslist2"], ["d1", "d2"])]
         expected_ordered = [(["zfslist2"], ["d1", "d2"])]
         results = list(
@@ -4449,7 +4449,7 @@ class TestItrSSHCmdParallel(unittest.TestCase):
         )
         self.assertEqual(results, expected_ordered)
 
-    def test_cmd_with_empty_arguments_unordered(self):
+    def test_cmd_with_empty_arguments_unordered(self) -> None:
         cmd_args_list = [(["zfslist1"], []), (["zfslist2"], ["d1", "d2"])]
         expected_ordered = [(["zfslist2"], ["d1", "d2"])]
         results = list(
@@ -4472,7 +4472,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         with self.lock:
             self.submitted.append(dataset)
 
-    def test_submit_no_skiptree(self):
+    def test_submit_no_skiptree(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4493,7 +4493,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
                 self.assertFalse(failed)
                 self.assertListEqual(["a1", "a1/b1", "a2"], sorted(self.submitted))
 
-    def test_submit_skiptree(self):
+    def test_submit_skiptree(self) -> None:
         def submit_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return False
@@ -4512,7 +4512,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
                 self.assertFalse(failed)
                 self.assertListEqual(["a1", "a2"], sorted(self.submitted))
 
-    def test_submit_zero_datasets(self):
+    def test_submit_zero_datasets(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4527,7 +4527,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertFalse(failed)
         self.assertListEqual([], sorted(self.submitted))
 
-    def test_submit_timeout_with_skip_on_error_is_fail(self):
+    def test_submit_timeout_with_skip_on_error_is_fail(self) -> None:
         def submit_raise_timeout(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             raise subprocess.TimeoutExpired("submit_raise_timeout", 10)
@@ -4543,7 +4543,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
             )
         self.assertListEqual(["a1"], sorted(self.submitted))
 
-    def test_submit_timeout_with_skip_on_error_is_not_fail(self):
+    def test_submit_timeout_with_skip_on_error_is_not_fail(self) -> None:
         def submit_raise_timeout(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             raise subprocess.TimeoutExpired("submit_raise_timeout", 10)
@@ -4562,7 +4562,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.append_submission(dataset)
         raise subprocess.CalledProcessError(1, "foo_cmd")
 
-    def test_submit_raise_error_with_skip_tree_on_error_is_false(self):
+    def test_submit_raise_error_with_skip_tree_on_error_is_false(self) -> None:
         src_datasets = ["a1", "a1/b1", "a2"]
         failed = self.job.process_datasets_in_parallel_and_fault_tolerant(
             src_datasets,
@@ -4573,7 +4573,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertTrue(failed)
         self.assertListEqual(["a1", "a1/b1", "a2"], sorted(self.submitted))
 
-    def test_submit_raise_error_with_skip_tree_on_error_is_true(self):
+    def test_submit_raise_error_with_skip_tree_on_error_is_true(self) -> None:
         src_datasets = ["a1", "a1/b1", "a2"]
         failed = self.job.process_datasets_in_parallel_and_fault_tolerant(
             src_datasets,
@@ -4584,7 +4584,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertTrue(failed)
         self.assertListEqual(["a1", "a2"], sorted(self.submitted))
 
-    def test_submit_barriers0a_no_skiptree(self):
+    def test_submit_barriers0a_no_skiptree(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4601,7 +4601,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertFalse(failed)
         self.assertListEqual(src_datasets, sorted(self.submitted))
 
-    def test_submit_barriers0a_with_skiptree(self):
+    def test_submit_barriers0a_with_skiptree(self) -> None:
         def submit_with_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return dataset != "a/b/c/0d"
@@ -4618,7 +4618,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertFalse(failed)
         self.assertListEqual(["a/b/c", "a/b/c/0d", "a/b/c/1d"], sorted(self.submitted))
 
-    def test_submit_barriers0b(self):
+    def test_submit_barriers0b(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4634,7 +4634,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertFalse(failed)
         self.assertListEqual(src_datasets, sorted(self.submitted))
 
-    def test_submit_barriers0c(self):
+    def test_submit_barriers0c(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4650,7 +4650,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertFalse(failed)
         self.assertListEqual(src_datasets, sorted(self.submitted))
 
-    def test_submit_barriers1(self):
+    def test_submit_barriers1(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4674,7 +4674,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertFalse(failed)
         self.assertListEqual(src_datasets, sorted(self.submitted))
 
-    def test_submit_barriers2(self):
+    def test_submit_barriers2(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4698,7 +4698,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
         self.assertFalse(failed)
         self.assertListEqual(src_datasets, sorted(self.submitted))
 
-    def test_submit_barriers3(self):
+    def test_submit_barriers3(self) -> None:
         def submit_no_skiptree(dataset: str, tid: str, retry: bzfs.Retry) -> bool:
             self.append_submission(dataset)
             return True
@@ -4726,7 +4726,7 @@ class TestProcessDatasetsInParallel(unittest.TestCase):
 #############################################################################
 class TestPerformance(unittest.TestCase):
 
-    def test_close_fds(self):
+    def test_close_fds(self) -> None:
         """see https://bugs.python.org/issue42738
         and https://github.com/python/cpython/pull/113118/commits/654f63053aee162a6e59fa894b2cd8ee82a33a77"""
         iters = 2000

--- a/bzfs_tests/test_bzfs.py
+++ b/bzfs_tests/test_bzfs.py
@@ -158,8 +158,8 @@ class TestHelperFunctions(unittest.TestCase):
         expected: List[Tuple[Any, ...]],
         src: Sequence[Any],
         dst: Sequence[Any],
-        choice=f"{s}+{d}+{a}",
-        invert=True,
+        choice: str = f"{s}+{d}+{a}",
+        invert: bool = True,
     ) -> None:
         s, d, a = self.s, self.d, self.a
         self.assertListEqual(expected, self.merge_sorted_iterators(src, dst, choice))
@@ -3653,7 +3653,7 @@ class TestPythonVersionCheck(unittest.TestCase):
 
     @patch("sys.exit")
     @patch("sys.version_info", new=(3, 6))
-    def test_version_below_3_8(self, mock_exit) -> None:
+    def test_version_below_3_8(self, mock_exit: MagicMock) -> None:
         with patch("sys.stderr"):
             import importlib
             from bzfs_main import bzfs
@@ -3663,7 +3663,7 @@ class TestPythonVersionCheck(unittest.TestCase):
 
     @patch("sys.exit")
     @patch("sys.version_info", new=(3, 8))
-    def test_version_3_8_or_higher(self, mock_exit) -> None:
+    def test_version_3_8_or_higher(self, mock_exit: MagicMock) -> None:
         import importlib
         from bzfs_main import bzfs
 

--- a/bzfs_tests/test_bzfs.py
+++ b/bzfs_tests/test_bzfs.py
@@ -35,7 +35,7 @@ from datetime import datetime, timedelta, timezone, tzinfo
 from logging import Logger
 from pathlib import Path
 from subprocess import PIPE
-from typing import Any, Container, DefaultDict, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import Any, Container, DefaultDict, Dict, List, Optional, Sequence, Set, Tuple, Union, cast, Iterator
 
 if sys.version_info < (3, 11):
 
@@ -1718,10 +1718,10 @@ class TestHelperFunctions(unittest.TestCase):
 
 #############################################################################
 class TestTerminateProcessSubtree(unittest.TestCase):
-    def setUp(self):
-        self.children = []
+    def setUp(self) -> None:
+        self.children: List[subprocess.Popen[Any]] = []
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for child in self.children:
             try:
                 child.kill()
@@ -2125,7 +2125,7 @@ class TestBuildTree(unittest.TestCase):
 #############################################################################
 class TestCurrentDateTime(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.fixed_datetime = datetime(2024, 1, 1, 12, 0, 0)  # in no timezone
 
     def test_now(self):
@@ -2230,7 +2230,7 @@ def round_datetime_up_to_duration_multiple(
 
 
 class TestRoundDatetimeUpToDurationMultiple(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         # Use a fixed timezone (e.g. Eastern Standard Time, UTC-5) for all tests.
         self.tz = timezone(timedelta(hours=-5))
 
@@ -2833,7 +2833,7 @@ class TestArgumentParser(unittest.TestCase):
 #############################################################################
 class TestDatasetPairsAction(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--input", nargs="+", action=bzfs.DatasetPairsAction)
 
@@ -2896,7 +2896,7 @@ class TestDatasetPairsAction(unittest.TestCase):
 #############################################################################
 class TestFileOrLiteralAction(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--input", nargs="+", action=bzfs.FileOrLiteralAction)
 
@@ -2932,7 +2932,7 @@ class TestFileOrLiteralAction(unittest.TestCase):
 #############################################################################
 class TestNewSnapshotFilterGroupAction(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--new-snapshot-filter-group", action=bzfs.NewSnapshotFilterGroupAction, nargs=0)
 
@@ -2947,14 +2947,14 @@ class TestNewSnapshotFilterGroupAction(unittest.TestCase):
 
 #############################################################################
 class TestTimeRangeAction(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--time-n-ranks", action=bzfs.TimeRangeAndRankRangeAction, nargs="+")
 
-    def parse_duration(self, arg):
+    def parse_duration(self, arg: str) -> argparse.Namespace:
         return self.parser.parse_args(["--time-n-ranks", arg + " ago..anytime"])
 
-    def parse_timestamp(self, arg):
+    def parse_timestamp(self, arg: str) -> argparse.Namespace:
         return self.parser.parse_args(["--time-n-ranks", arg + "..anytime"])
 
     def test_parse_unix_time(self):  # Test Unix time in integer seconds
@@ -3166,11 +3166,11 @@ def filter_snapshots_by_times_and_rank(
 #############################################################################
 class TestRankRangeAction(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--ranks", nargs="+", action=bzfs.TimeRangeAndRankRangeAction)
 
-    def parse_args(self, arg):
+    def parse_args(self, arg: str) -> argparse.Namespace:
         return self.parser.parse_args(["--ranks", "0..0", arg])
 
     def test_valid_ranks(self):
@@ -3421,7 +3421,7 @@ class TestRankRangeAction(unittest.TestCase):
 #############################################################################
 class TestLogConfigVariablesAction(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--log-config-var", nargs="+", action=bzfs.LogConfigVariablesAction)
 
@@ -3437,7 +3437,7 @@ class TestLogConfigVariablesAction(unittest.TestCase):
 #############################################################################
 class TestSafeFileNameAction(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("filename", action=bzfs.SafeFileNameAction)
 
@@ -3656,7 +3656,7 @@ class TestPythonVersionCheck(unittest.TestCase):
 
 #############################################################################
 class TestConnectionPool(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         args = argparser_parse_args(args=["src", "dst", "-v"])
         p = bzfs.Params(args, log=bzfs.get_logger(bzfs.LogParams(args), args))
         self.src = p.src
@@ -4069,7 +4069,7 @@ class TestIncrementalSendSteps(unittest.TestCase):
 
 #############################################################################
 class TestSmallPriorityQueue(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.pq: bzfs.SmallPriorityQueue[int] = bzfs.SmallPriorityQueue()
         self.pq_reverse: bzfs.SmallPriorityQueue[int] = bzfs.SmallPriorityQueue(reverse=True)
 
@@ -4253,7 +4253,7 @@ class TestSynchronizedBool(unittest.TestCase):
 
 #############################################################################
 class TestSynchronizedDict(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.sync_dict = bzfs.SynchronizedDict({"a": 1, "b": 2, "c": 3})
 
     def test_getitem(self):
@@ -4307,11 +4307,11 @@ class TestSynchronizedDict(unittest.TestCase):
 
 #############################################################################
 # class TestItrSSHCmdParallel(unittest.TestCase)
-def dummy_fn_ordered(cmd, batch):
+def dummy_fn_ordered(cmd: List[str], batch: List[str]) -> Tuple[List[str], List[str]]:
     return cmd, batch
 
 
-def dummy_fn_unordered(cmd, batch):
+def dummy_fn_unordered(cmd: List[str], batch: List[str]) -> Tuple[List[str], List[str]]:
     if cmd[0] == "zfslist1":
         time.sleep(0.2)
     elif cmd[0] == "zfslist2":
@@ -4319,13 +4319,13 @@ def dummy_fn_unordered(cmd, batch):
     return cmd, batch
 
 
-def dummy_fn_raise(cmd, batch):
+def dummy_fn_raise(cmd: List[str], batch: List[str]) -> Tuple[List[str], List[str]]:
     if cmd[0] == "fail":
         raise ValueError("Intentional failure")
     return cmd, batch
 
 
-def dummy_fn_race(cmd, batch):
+def dummy_fn_race(cmd: List[str], batch: List[str]) -> Tuple[List[str], List[str]]:
     if cmd[0] == "zfslist1":
         time.sleep(0.3)
     elif cmd[0] == "zfslist2":
@@ -4336,7 +4336,7 @@ def dummy_fn_race(cmd, batch):
 
 
 class TestItrSSHCmdParallel(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         args = argparser_parse_args(args=["src", "dst"])
         p = bzfs.Params(args)
         job = cast(Any, bzfs.Job())
@@ -4368,7 +4368,7 @@ class TestItrSSHCmdParallel(unittest.TestCase):
             (["zfslist2"], ["b4", "b5"]),
         ]
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         bzfs.reset_logger()
 
     def test_ordered_with_max_batch_items_2(self):
@@ -4460,13 +4460,13 @@ class TestItrSSHCmdParallel(unittest.TestCase):
 
 #############################################################################
 class TestProcessDatasetsInParallel(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         args = argparser_parse_args(args=["src", "dst"])
         p = bzfs.Params(args, log=bzfs.get_simple_logger("myprogram"))
         self.job = bzfs.Job()
         self.job.params = p
         self.lock = threading.Lock()
-        self.submitted = []
+        self.submitted: List[str] = []
 
     def append_submission(self, dataset):
         with self.lock:
@@ -4745,7 +4745,7 @@ class TestPerformance(unittest.TestCase):
 
 
 @contextmanager
-def stop_on_failure_subtest(**params):
+def stop_on_failure_subtest(**params: Any) -> Iterator[None]:
     """Context manager to mimic UnitTest.subTest() but stop on first failure"""
     try:
         yield

--- a/bzfs_tests/test_integrations.py
+++ b/bzfs_tests/test_integrations.py
@@ -438,7 +438,7 @@ class BZFSTestCase(ParametrizedTestCase):
         args = args + ["--exclude-envvar-regex=EDITOR"]
         args += ["--cache-snapshots=" + str(cache_snapshots).lower()]
 
-        job: Any
+        job: Union[bzfs.Job, bzfs_jobrunner.Job]
         if use_jobrunner:
             job = bzfs_jobrunner.Job()
             job.is_test_mode = True
@@ -448,28 +448,28 @@ class BZFSTestCase(ParametrizedTestCase):
             job = bzfs.Job()
             job.is_test_mode = True
 
-        if error_injection_triggers is not None:
+        if error_injection_triggers is not None and isinstance(job, bzfs.Job):
             job.error_injection_triggers = error_injection_triggers
             args = args + ["--threads=1"]
 
-        if delete_injection_triggers is not None:
+        if delete_injection_triggers is not None and isinstance(job, bzfs.Job):
             job.delete_injection_triggers = delete_injection_triggers
             args = args + ["--threads=1"]
 
-        if param_injection_triggers is not None:
+        if param_injection_triggers is not None and isinstance(job, bzfs.Job):
             job.param_injection_triggers = param_injection_triggers
             args = args + ["--threads=1"]
 
-        if inject_params is not None:
+        if inject_params is not None and isinstance(job, bzfs.Job):
             job.inject_params = inject_params
 
-        if max_command_line_bytes is not None:
+        if max_command_line_bytes is not None and isinstance(job, bzfs.Job):
             job.max_command_line_bytes = max_command_line_bytes
 
-        if creation_prefix is not None:
+        if creation_prefix is not None and isinstance(job, bzfs.Job):
             job.creation_prefix = creation_prefix
 
-        if max_exceptions_to_summarize is not None:
+        if max_exceptions_to_summarize is not None and isinstance(job, bzfs.Job):
             job.max_exceptions_to_summarize = max_exceptions_to_summarize
 
         old_max_datasets_per_minibatch_on_list_snaps = os.environ.get(
@@ -497,16 +497,16 @@ class BZFSTestCase(ParametrizedTestCase):
                 include_snapshot_plan_excludes_outdated_snapshots
             )
 
-        if control_persist_margin_secs is not None:
+        if control_persist_margin_secs is not None and isinstance(job, bzfs.Job):
             job.control_persist_margin_secs = control_persist_margin_secs
 
-        if isatty is not None:
+        if isatty is not None and isinstance(job, bzfs.Job):
             job.isatty = isatty
 
-        if use_select is not None:
+        if use_select is not None and isinstance(job, bzfs.Job):
             job.use_select = use_select
 
-        if progress_update_intervals is not None:
+        if progress_update_intervals is not None and isinstance(job, bzfs.Job):
             job.progress_update_intervals = progress_update_intervals
 
         returncode = 0

--- a/bzfs_tests/test_integrations.py
+++ b/bzfs_tests/test_integrations.py
@@ -644,22 +644,22 @@ class BZFSTestCase(ParametrizedTestCase):
 class SmokeTestCase(BZFSTestCase):
     """Runs only a small subset of tests."""
 
-    def test_include_snapshots_plan(self):
+    def test_include_snapshots_plan(self) -> None:
         LocalTestCase(param=self.param).test_include_snapshots_plan()
 
-    def test_basic_replication_recursive1(self):
+    def test_basic_replication_recursive1(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_recursive1()
 
-    def test_delete_dst_snapshots_except_plan(self):
+    def test_delete_dst_snapshots_except_plan(self) -> None:
         LocalTestCase(param=self.param).test_delete_dst_snapshots_except_plan()
 
-    def test_basic_snapshotting_flat_simple(self):
+    def test_basic_snapshotting_flat_simple(self) -> None:
         LocalTestCase(param=self.param).test_basic_snapshotting_flat_simple()
 
-    def test_jobrunner_flat_simple(self):
+    def test_jobrunner_flat_simple(self) -> None:
         LocalTestCase(param=self.param).test_jobrunner_flat_simple()
 
-    def test_xbasic_replication_flat_with_bookmarks1(self):
+    def test_xbasic_replication_flat_with_bookmarks1(self) -> None:
         LocalTestCase(param=self.param).test_xbasic_replication_flat_with_bookmarks1()
 
 
@@ -668,80 +668,80 @@ class AdhocTestCase(BZFSTestCase):
     """For testing isolated changes you are currently working on. You can temporarily change the list of tests here.
     The current list is arbitrary and subject to change at any time."""
 
-    def test_send_full_resume_recv(self):
+    def test_send_full_resume_recv(self) -> None:
         LocalTestCase(param=self.param).test_send_full_resume_recv()
 
-    # def test_include_snapshots_plan(self):
+    # def test_include_snapshots_plan(self) -> None:
     #     LocalTestCase(param=self.param).test_include_snapshots_plan()
     #
-    # def test_include_snapshots_plan_without_excludes_outdated_snapshots(self):
+    # def test_include_snapshots_plan_without_excludes_outdated_snapshots(self) -> None:
     #     LocalTestCase(param=self.param).test_include_snapshots_plan_without_excludes_outdated_snapshots()
     #
-    # def test_delete_dst_snapshots_except_plan(self):
+    # def test_delete_dst_snapshots_except_plan(self) -> None:
     #     LocalTestCase(param=self.param).test_delete_dst_snapshots_except_plan()
     #
-    # def test_daemon_frequency(self):
+    # def test_daemon_frequency(self) -> None:
     #     LocalTestCase(param=self.param).test_daemon_frequency()
     #
-    # def test_daemon_frequency_invalid(self):
+    # def test_daemon_frequency_invalid(self) -> None:
     #     LocalTestCase(param=self.param).test_daemon_frequency_invalid()
     #
-    # def test_basic_snapshotting_flat_simple(self):
+    # def test_basic_snapshotting_flat_simple(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_flat_simple()
     #
-    # def test_basic_snapshotting_flat_non_existing_root(self):
+    # def test_basic_snapshotting_flat_non_existing_root(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_flat_non_existing_root()
     #
-    # def test_basic_snapshotting_flat_empty(self):
+    # def test_basic_snapshotting_flat_empty(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_flat_empty()
     #
-    # def test_basic_snapshotting_recursive_simple(self):
+    # def test_basic_snapshotting_recursive_simple(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_recursive_simple()
     #
-    # def test_basic_snapshotting_recursive_with_skip_parent(self):
+    # def test_basic_snapshotting_recursive_with_skip_parent(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_recursive_with_skip_parent()
     #
-    # def test_basic_snapshotting_recursive_simple_with_incompatible_pruning(self):
+    # def test_basic_snapshotting_recursive_simple_with_incompatible_pruning(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_recursive_simple_with_incompatible_pruning()
     #
-    # def test_basic_snapshotting_recursive_simple_with_incompatible_pruning_with_skip_parent(self):
+    # def test_basic_snapshotting_recursive_simple_with_incompatible_pruning_with_skip_parent(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_recursive_simple_with_incompatible_pruning_with_skip_parent()
     #
-    # def test_basic_snapshotting_flat_even_if_not_due(self):
+    # def test_basic_snapshotting_flat_even_if_not_due(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_flat_even_if_not_due()
     #
-    # def test_invalid_use_of_dummy(self):
+    # def test_invalid_use_of_dummy(self) -> None:
     #     LocalTestCase(param=self.param).test_invalid_use_of_dummy()
     #
-    # def test_basic_snapshotting_flat_daemon(self):
+    # def test_basic_snapshotting_flat_daemon(self) -> None:
     #     LocalTestCase(param=self.param).test_basic_snapshotting_flat_daemon()
     #
-    # def test_big_snapshotting_generates_identical_createtxg_despite_incompatible_pruning(self):
+    # def test_big_snapshotting_generates_identical_createtxg_despite_incompatible_pruning(self) -> None:
     #     LocalTestCase(param=self.param).test_big_snapshotting_generates_identical_createtxg_despite_incompatible_pruning()
     #
-    # def test_jobrunner_flat_simple(self):
+    # def test_jobrunner_flat_simple(self) -> None:
     #     LocalTestCase(param=self.param).test_jobrunner_flat_simple()
     #
-    # def test_jobrunner_flat_simple_with_empty_targets(self):
+    # def test_jobrunner_flat_simple_with_empty_targets(self) -> None:
     #     LocalTestCase(param=self.param).test_jobrunner_flat_simple_with_empty_targets()
     #
-    # def test_last_replicated_cache_with_no_sleep(self):
+    # def test_last_replicated_cache_with_no_sleep(self) -> None:
     #     LocalTestCase(param=self.param).test_last_replicated_cache_with_no_sleep()
     #
-    # def test_last_replicated_cache_with_sleep_longer_than_threshold(self):
+    # def test_last_replicated_cache_with_sleep_longer_than_threshold(self) -> None:
     #     LocalTestCase(param=self.param).test_last_replicated_cache_with_sleep_longer_than_threshold()
     #
-    # def test_cache_flat_simple(self):
+    # def test_cache_flat_simple(self) -> None:
     #     LocalTestCase(param=self.param).test_cache_flat_simple()
     #
-    # def test_cache_flat_simple_subset(self):
+    # def test_cache_flat_simple_subset(self) -> None:
     #     LocalTestCase(param=self.param).test_cache_flat_simple_subset()
 
 
 #############################################################################
 class IncrementalSendStepsTestCase(BZFSTestCase):
 
-    def test_snapshot_series_excluding_hourlies(self):
+    def test_snapshot_series_excluding_hourlies(self) -> None:
         testcase = {None: ["d1", "h1", "d2", "d3", "d4"]}
         expected_results = ["d1", "d2", "d3", "d4"]
         dst_foo = dst_root_dataset + "/foo"
@@ -837,7 +837,7 @@ class IncrementalSendStepsTestCase(BZFSTestCase):
         )
         self.assertSnapshotNames(dst_foo, [])
 
-    def test_snapshot_series_excluding_hourlies_with_permutations(self):
+    def test_snapshot_series_excluding_hourlies_with_permutations(self) -> None:
         for testcase in TestIncrementalSendSteps().permute_snapshot_series(5):
             self.tearDownAndSetup()
             src_foo = create_filesystem(src_root_dataset, "foo")
@@ -870,7 +870,7 @@ class TestSSHLatency(BZFSTestCase):
         process = subprocess.run(cmd, stdin=DEVNULL, stdout=PIPE, stderr=PIPE, text=True, check=True, close_fds=close_fds)
         return process.stdout[0:-1], process.stderr[0:-1]  # omit trailing newline char
 
-    def test_ssh_loopback_latency(self):
+    def test_ssh_loopback_latency(self) -> None:
         self.setup_basic()
         args = bzfs.argument_parser().parse_args(args=["src", "dst"])
         p = bzfs.Params(args, log_params=bzfs.LogParams(args))
@@ -952,7 +952,7 @@ class TestSSHLatency(BZFSTestCase):
 #############################################################################
 class LocalTestCase(BZFSTestCase):
 
-    def test_basic_snapshotting_flat_simple(self):
+    def test_basic_snapshotting_flat_simple(self) -> None:
         destroy(dst_root_dataset, recursive=True)
         self.assertSnapshots(src_root_dataset, 0)
         for i in range(0, 6):
@@ -1011,7 +1011,7 @@ class LocalTestCase(BZFSTestCase):
                         ],
                     )
 
-    def test_basic_snapshotting_recursive_simple(self):
+    def test_basic_snapshotting_recursive_simple(self) -> None:
         q = 0
         for m in range(0, 2):
             for k in range(0, 2):
@@ -1058,7 +1058,7 @@ class LocalTestCase(BZFSTestCase):
                                         self.assertEqual(1, len(snapshots(dataset + "/foo/b")))
                                     self.assert_snapshotting_generates_identical_createtxg()
 
-    def test_basic_snapshotting_recursive_with_skip_parent(self):
+    def test_basic_snapshotting_recursive_with_skip_parent(self) -> None:
         self.setup_basic()
         destroy(dst_root_dataset, recursive=True)
         n = 3
@@ -1090,7 +1090,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertEqual(1, len(snapshots(src_root_dataset + "/foo/b")))
                     self.assert_snapshotting_generates_identical_createtxg()
 
-    def test_basic_snapshotting_recursive_simple_with_incompatible_pruning(self):
+    def test_basic_snapshotting_recursive_simple_with_incompatible_pruning(self) -> None:
         self.setup_basic()
         destroy(dst_root_dataset, recursive=True)
         n = 3
@@ -1122,7 +1122,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertEqual(1, len(snapshots(src_root_dataset + "/foo/b")))
                     self.assert_snapshotting_generates_identical_createtxg()
 
-    def test_basic_snapshotting_recursive_simple_with_incompatible_pruning_with_skip_parent(self):
+    def test_basic_snapshotting_recursive_simple_with_incompatible_pruning_with_skip_parent(self) -> None:
         self.setup_basic()
         destroy(dst_root_dataset, recursive=True)
         n = 3
@@ -1155,7 +1155,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertEqual(1, len(snapshots(src_root_dataset + "/foo/b")))
                     self.assert_snapshotting_generates_identical_createtxg()
 
-    def test_big_snapshotting_generates_identical_createtxg_despite_incompatible_pruning(self):
+    def test_big_snapshotting_generates_identical_createtxg_despite_incompatible_pruning(self) -> None:
         if test_mode == "functional":
             self.skipTest("Skipping slow test")
         # k = 50
@@ -1204,7 +1204,7 @@ class LocalTestCase(BZFSTestCase):
         # even if "--exclude-dataset-regex=.*xxx" is commented out therein.
         # self.assertEqual(1, len(creations))
 
-    def test_basic_snapshotting_flat_empty(self):
+    def test_basic_snapshotting_flat_empty(self) -> None:
         destroy(dst_root_dataset, recursive=True)
         self.assertSnapshots(src_root_dataset, 0)
         for i in range(0, 1):
@@ -1220,7 +1220,7 @@ class LocalTestCase(BZFSTestCase):
                 self.assertFalse(dataset_exists(dst_root_dataset))
                 self.assertSnapshots(src_root_dataset, 0)
 
-    def test_basic_snapshotting_flat_non_existing_root(self):
+    def test_basic_snapshotting_flat_non_existing_root(self) -> None:
         destroy(src_root_dataset, recursive=True)
         destroy(dst_root_dataset, recursive=True)
         self.run_bzfs(
@@ -1232,7 +1232,7 @@ class LocalTestCase(BZFSTestCase):
             expected_status=die_status,
         )
 
-    def test_basic_snapshotting_flat_even_if_not_due(self):
+    def test_basic_snapshotting_flat_even_if_not_due(self) -> None:
         take_snapshot(src_root_dataset, "s1_onsite_9999-01-01_00:00:00_hourly")
         take_snapshot(src_root_dataset, "s1_onsite_9999-01-01_00:00:00_daily")
         self.run_bzfs(
@@ -1245,7 +1245,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshotNameRegexes(src_root_dataset, ["s1.*_hourly", "s1.*_daily", "s1.*_hourly"])
 
-    def test_basic_snapshotting_flat_daemon(self):
+    def test_basic_snapshotting_flat_daemon(self) -> None:
         destroy(dst_root_dataset, recursive=True)
         self.run_bzfs(
             src_root_dataset,
@@ -1264,15 +1264,15 @@ class LocalTestCase(BZFSTestCase):
             self.assertSnapshotNameRegexes(src_root_dataset, expected)
             self.assertSnapshotNameRegexes(dst_root_dataset, expected)
 
-    def test_daemon_frequency(self):
+    def test_daemon_frequency(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--daemon-frequency=1secondly")
 
-    def test_daemon_frequency_invalid(self):
+    def test_daemon_frequency_invalid(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--daemon-frequency=1second", expected_status=die_status)
 
-    def test_invalid_use_of_dummy(self):
+    def test_invalid_use_of_dummy(self) -> None:
         self.run_bzfs(src_root_dataset, bzfs.dummy_dataset, expected_status=die_status)
         self.run_bzfs(
             src_root_dataset, bzfs.dummy_dataset, "--skip-replication", "--delete-dst-snapshots", expected_status=die_status
@@ -1287,7 +1287,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.run_bzfs(bzfs.dummy_dataset, bzfs.dummy_dataset, expected_status=die_status)
 
-    def test_include_snapshots_plan(self):
+    def test_include_snapshots_plan(self) -> None:
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:00_secondly")
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:01_secondly")
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:00_daily")
@@ -1303,7 +1303,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshotNames(dst_root_dataset, ["s1_onsite_2024-01-01_00:00:01_secondly"])
 
-    def test_include_snapshots_plan_without_excludes_outdated_snapshots(self):
+    def test_include_snapshots_plan_without_excludes_outdated_snapshots(self) -> None:
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:00_secondly")
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:01_secondly")
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:00_daily")
@@ -1319,7 +1319,7 @@ class LocalTestCase(BZFSTestCase):
             dst_root_dataset, ["s1_onsite_2024-01-01_00:00:00_secondly", "s1_onsite_2024-01-01_00:00:01_secondly"]
         )
 
-    def test_delete_dst_snapshots_except_plan(self):
+    def test_delete_dst_snapshots_except_plan(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("Destroying snapshots on src needs extra permissions")
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:00_secondly")
@@ -1419,7 +1419,7 @@ class LocalTestCase(BZFSTestCase):
             expected_status=2,
         )
 
-    def test_delete_dst_snapshots_except_with_source(self):
+    def test_delete_dst_snapshots_except_with_source(self) -> None:
         take_snapshot(src_root_dataset, fix("s1_hourly"))
         take_snapshot(src_root_dataset, fix("s2_daily"))
         take_snapshot(src_root_dataset, fix("s3_weekly"))
@@ -1442,7 +1442,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshotNames(dst_root_dataset, ["s2_daily"])
 
-    def test_delete_dst_snapshots_except_with_dummy_source0(self):
+    def test_delete_dst_snapshots_except_with_dummy_source0(self) -> None:
         take_snapshot(dst_root_dataset, fix("s1_hourly"))
         take_snapshot(dst_root_dataset, fix("s2_daily"))
         take_snapshot(dst_root_dataset, fix("s3_weekly"))
@@ -1459,7 +1459,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshotNames(dst_root_dataset, ["s2_daily"])
 
-    def test_delete_dst_snapshots_except_with_dummy_source1(self):
+    def test_delete_dst_snapshots_except_with_dummy_source1(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("Destroying snapshots on src needs extra permissions")
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:00_secondly")
@@ -1493,7 +1493,7 @@ class LocalTestCase(BZFSTestCase):
             src_root_dataset, ["s1_onsite_2024-01-01_00:02:00_secondly", "s1_onsite_2024-01-03_00:00:00_millisecondly"]
         )
 
-    def test_delete_dst_snapshots_except_with_dummy_source2(self):
+    def test_delete_dst_snapshots_except_with_dummy_source2(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("Destroying snapshots on src needs extra permissions")
         take_snapshot(src_root_dataset, "s1_onsite_2024-01-01_00:00:00_secondly")
@@ -1536,7 +1536,7 @@ class LocalTestCase(BZFSTestCase):
             ],
         )
 
-    def test_basic_replication_flat_simple(self):
+    def test_basic_replication_flat_simple(self) -> None:
         self.setup_basic()
         for i in range(0, 3):
             with stop_on_failure_subtest(i=i):
@@ -1561,7 +1561,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertTrue(job.is_program_available("pv", loc))
                     self.assertTrue(job.is_program_available("ps", loc))
 
-    def test_basic_replication_flat_simple_with_progress_reporter(self):
+    def test_basic_replication_flat_simple_with_progress_reporter(self) -> None:
         for pv_program in ["pv", bzfs.disable_prg]:
             for i in range(0, 3):
                 with stop_on_failure_subtest(i=i):
@@ -1578,7 +1578,7 @@ class LocalTestCase(BZFSTestCase):
                     )
                     self.assertSnapshots(dst_root_dataset, n, "s")
 
-    def test_progress_reporter_validation(self):
+    def test_progress_reporter_validation(self) -> None:
         self.setup_basic()
 
         # --pv-program-opts must contain one of --bytes or --bits for progress metrics to function
@@ -1617,10 +1617,10 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_basic_replication_recursive1_with_volume(self):
+    def test_basic_replication_recursive1_with_volume(self) -> None:
         self.test_basic_replication_recursive1(volume=True)
 
-    def test_basic_replication_recursive1(self, volume=False):
+    def test_basic_replication_recursive1(self, volume=False) -> None:
         self.assertTrue(dataset_exists(dst_root_dataset))
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.setup_basic(volume=volume)
@@ -1645,7 +1645,7 @@ class LocalTestCase(BZFSTestCase):
                     encryption_prop = dataset_property(dst_root_dataset + "/foo/a", "encryption")
                     self.assertEqual(encryption_prop, encryption_algo if self.is_encryption_mode() else "off")
 
-    def test_basic_replication_recursive_parallel(self):
+    def test_basic_replication_recursive_parallel(self) -> None:
         self.assertTrue(dataset_exists(dst_root_dataset))
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.setup_basic()
@@ -1685,7 +1685,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertBookmarkNames(src_root_dataset + "/foo", [])
                     self.assertBookmarkNames(src_root_dataset + "/foo/a", [])
 
-    def test_basic_replication_flat_pool(self):
+    def test_basic_replication_flat_pool(self) -> None:
         for child in datasets(src_pool) + datasets(dst_pool):
             destroy(child, recursive=True)
         for snapshot in snapshots(src_pool) + snapshots(dst_pool):
@@ -1717,7 +1717,7 @@ class LocalTestCase(BZFSTestCase):
                 else:
                     self.assertSnapshots(dst_pool, 1, "p")
 
-    def test_basic_replication_missing_pools(self):
+    def test_basic_replication_missing_pools(self) -> None:
         for child in datasets(src_pool) + datasets(dst_pool):
             destroy(child, recursive=True)
         for snapshot in snapshots(src_pool) + snapshots(dst_pool):
@@ -1739,7 +1739,7 @@ class LocalTestCase(BZFSTestCase):
                 self.run_bzfs(src_pool, dst_pool, dry_run=(i == 0), expected_status=die_status)
                 self.assertFalse(dataset_exists(src_pool))
 
-    def test_basic_replication_flat_nonzero_snapshots_create_parents(self):
+    def test_basic_replication_flat_nonzero_snapshots_create_parents(self) -> None:
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo/a"))
         self.setup_basic()
@@ -1752,7 +1752,7 @@ class LocalTestCase(BZFSTestCase):
                 else:
                     self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
 
-    def test_basic_replication_flat_no_snapshot_dont_create_parents(self):
+    def test_basic_replication_flat_no_snapshot_dont_create_parents(self) -> None:
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo/b"))
         self.setup_basic()
         for i in range(0, 2):
@@ -1760,7 +1760,7 @@ class LocalTestCase(BZFSTestCase):
                 self.run_bzfs(src_root_dataset + "/foo/b", dst_root_dataset + "/foo/b", dry_run=(i == 0))
                 self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
 
-    def test_basic_replication_flat_simple_with_dry_run_no_send(self):
+    def test_basic_replication_flat_simple_with_dry_run_no_send(self) -> None:
         self.setup_basic()
         self.assertTrue(dataset_exists(dst_root_dataset))
         for i in range(0, 2):
@@ -1772,14 +1772,14 @@ class LocalTestCase(BZFSTestCase):
                 else:
                     self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_basic_replication_flat_nothing_todo(self):
+    def test_basic_replication_flat_nothing_todo(self) -> None:
         for i in range(0, 2):
             with stop_on_failure_subtest(i=i):
                 self.run_bzfs(src_root_dataset, dst_root_dataset, dry_run=(i == 0))
                 self.assertSnapshots(dst_root_dataset, 0)
                 self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
 
-    def test_basic_replication_without_source(self):
+    def test_basic_replication_without_source(self) -> None:
         destroy(src_root_dataset, recursive=True)
         recreate_filesystem(dst_root_dataset)
         for i in range(0, 2):
@@ -1788,7 +1788,7 @@ class LocalTestCase(BZFSTestCase):
                 self.assertTrue(dataset_exists(dst_root_dataset))
                 self.assertSnapshots(dst_root_dataset, 0)
 
-    def test_basic_replication_flat_simple_with_skip_parent(self):
+    def test_basic_replication_flat_simple_with_skip_parent(self) -> None:
         self.setup_basic()
         for i in range(0, 2):
             with stop_on_failure_subtest(i=i):
@@ -1804,7 +1804,7 @@ class LocalTestCase(BZFSTestCase):
                 self.assertTrue(dataset_exists(dst_root_dataset))
                 self.assertSnapshots(dst_root_dataset, 0)
 
-    def test_basic_replication_recursive_with_skip_parent(self):
+    def test_basic_replication_recursive_with_skip_parent(self) -> None:
         self.setup_basic()
         self.setup_basic_woo()
         destroy(dst_root_dataset, recursive=True)
@@ -1842,7 +1842,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertSnapshots(dst_root_dataset + "/foo", 3, "t")
                     self.assertSnapshots(dst_root_dataset + "/woo0", 3, "w")
 
-    def test_last_replicated_cache_with_no_sleep(self):
+    def test_last_replicated_cache_with_no_sleep(self) -> None:
         destroy(dst_root_dataset, recursive=True)
         self.run_bzfs(
             src_root_dataset,
@@ -1856,7 +1856,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_bzfs(src_root_dataset, dst_root_dataset, cache_snapshots=True)
         self.assertEqual(1, len(snapshots(dst_root_dataset)))
 
-    def test_last_replicated_cache_with_sleep_longer_than_threshold(self):
+    def test_last_replicated_cache_with_sleep_longer_than_threshold(self) -> None:
         destroy(dst_root_dataset, recursive=True)
         self.run_bzfs(
             src_root_dataset,
@@ -1871,7 +1871,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_bzfs(src_root_dataset, dst_root_dataset, cache_snapshots=True)
         self.assertEqual(1, len(snapshots(dst_root_dataset)))
 
-    def test_include_snapshot_time_range_full(self):
+    def test_include_snapshot_time_range_full(self) -> None:
         self.setup_basic()
         self.run_bzfs(
             src_root_dataset,
@@ -1881,7 +1881,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_include_snapshot_time_range_empty(self):
+    def test_include_snapshot_time_range_empty(self) -> None:
         self.setup_basic()
         self.run_bzfs(
             src_root_dataset,
@@ -1890,7 +1890,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshots(dst_root_dataset, 0)
 
-    def test_include_snapshot_time_range_full_with_existing_nonempty_dst(self):
+    def test_include_snapshot_time_range_full_with_existing_nonempty_dst(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset)
         destroy(snapshots(dst_root_dataset)[-1])
@@ -1901,7 +1901,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_include_snapshot_time_range_full_with_existing_nonempty_dst_no_use_bookmark(self):
+    def test_include_snapshot_time_range_full_with_existing_nonempty_dst_no_use_bookmark(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset)
         destroy(snapshots(dst_root_dataset)[-1])
@@ -1913,7 +1913,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_include_snapshot_rank_range_full(self):
+    def test_include_snapshot_rank_range_full(self) -> None:
         self.setup_basic()
         self.run_bzfs(
             src_root_dataset,
@@ -1925,7 +1925,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_include_snapshot_rank_range_empty(self):
+    def test_include_snapshot_rank_range_empty(self) -> None:
         self.setup_basic()
         self.run_bzfs(
             src_root_dataset,
@@ -1939,7 +1939,7 @@ class LocalTestCase(BZFSTestCase):
     def run_snapshot_filters(self, filter1, filter2, filter3):
         self.run_bzfs(src_root_dataset, dst_root_dataset, *filter1, *filter2, *filter3, creation_prefix=creation_prefix)
 
-    def test_snapshot_filter_order_matters(self):
+    def test_snapshot_filter_order_matters(self) -> None:
         # "creation" zfs property cannot be manually set or modified or easily mocked.
         # Thus, for checks during testing we use the "bzfs_test:creation" property instead of the "creation" property.
         for snap in ["2024-01-01d", "2024-01-02d", "2024-01-03d", "2024-01-04d", "2024-01-05h"]:
@@ -1975,7 +1975,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_snapshot_filters(times_filter, ranks_filter, regex_filter)
         self.assertSnapshotNames(dst_root_dataset, ["2024-01-03d"])
 
-    def test_snapshot_filter_regexes_dont_merge_across_groups(self):
+    def test_snapshot_filter_regexes_dont_merge_across_groups(self) -> None:
         for snap in ["2024-01-01d", "2024-01-02d", "2024-01-03h", "2024-01-04dt"]:
             unix_time = bzfs.unixtime_fromisoformat(snap[0 : len("2024-01-01")])
             take_snapshot(src_root_dataset, fix(snap), props=["-o", creation_prefix + f"creation={unix_time}"])
@@ -1994,7 +1994,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_snapshot_filters(regex_filter_daily, regex_filter_test, ranks_filter)
         self.assertSnapshotNames(dst_root_dataset, ["2024-01-01d"])
 
-    def test_snapshot_filter_ranks_dont_merge_across_groups(self):
+    def test_snapshot_filter_ranks_dont_merge_across_groups(self) -> None:
         for snap in ["2024-01-01d", "2024-01-02h", "2024-01-03d", "2024-01-04dt"]:
             unix_time = bzfs.unixtime_fromisoformat(snap[0 : len("2024-01-01")])
             take_snapshot(src_root_dataset, fix(snap), props=["-o", creation_prefix + f"creation={unix_time}"])
@@ -2013,7 +2013,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_snapshot_filters(ranks_filter1, regex_filter_daily, ranks_filter2)
         self.assertSnapshotNames(dst_root_dataset, ["2024-01-03d"])
 
-    def test_snapshot_filter_groups(self):
+    def test_snapshot_filter_groups(self) -> None:
         for snap in ["2024-01-01d", "2024-01-02h", "2024-01-03d", "2024-01-04dt"]:
             unix_time = bzfs.unixtime_fromisoformat(snap[0 : len("2024-01-01")])
             take_snapshot(src_root_dataset, fix(snap), props=["-o", creation_prefix + f"creation={unix_time}"])
@@ -2033,7 +2033,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_bzfs(src_root_dataset, dst_root_dataset, *snapshot_filter, creation_prefix=creation_prefix)
         self.assertSnapshotNames(dst_root_dataset, ["2024-01-01d", "2024-01-02h", "2024-01-04dt"])
 
-    def test_nostream(self):
+    def test_nostream(self) -> None:
         self.setup_basic()
         for i in range(0, 3):
             with stop_on_failure_subtest(i=i):
@@ -2062,17 +2062,17 @@ class LocalTestCase(BZFSTestCase):
                 else:
                     self.assertSnapshotNames(dst_root_dataset, ["s3", "s4", "s6"])
 
-    def test_basic_replication_with_no_datasets_1(self):
+    def test_basic_replication_with_no_datasets_1(self) -> None:
         self.setup_basic()
         self.run_bzfs(expected_status=2)
 
     @patch("sys.argv", ["bzfs.py"])
-    def test_basic_replication_with_no_datasets_2(self):
+    def test_basic_replication_with_no_datasets_2(self) -> None:
         with self.assertRaises(SystemExit) as e:
             bzfs.main()
         self.assertEqual(e.exception.code, 2)
 
-    def test_basic_replication_dataset_with_spaces(self):
+    def test_basic_replication_dataset_with_spaces(self) -> None:
         d1 = " foo  zoo  "
         src_foo = create_filesystem(src_root_dataset, d1)
         s1 = fix(" s  nap1   ")
@@ -2087,20 +2087,20 @@ class LocalTestCase(BZFSTestCase):
         self.assertTrue(dataset_exists(dst_root_dataset + "/" + d1 + "/" + d2))
         self.assertSnapshotNames(dst_root_dataset + "/" + d1 + "/" + d2, [t1])
 
-    def test_basic_replication_flat_simple_with_timeout_infinity(self):
+    def test_basic_replication_flat_simple_with_timeout_infinity(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--timeout=1000seconds")
         self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_basic_replication_flat_simple_with_timeout_zero(self):
+    def test_basic_replication_flat_simple_with_timeout_zero(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--timeout=0seconds", expected_status=die_status)
 
-    def test_basic_replication_flat_simple_with_timeout_almost_zero(self):
+    def test_basic_replication_flat_simple_with_timeout_almost_zero(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--timeout=1milliseconds", expected_status=die_status)
 
-    def test_basic_replication_flat_simple_with_exclude_envvar(self):
+    def test_basic_replication_flat_simple_with_exclude_envvar(self) -> None:
         self.setup_basic()
         param_name = "EDITOR"
         old_value = os.environ.get(param_name)
@@ -2114,7 +2114,7 @@ class LocalTestCase(BZFSTestCase):
             else:
                 os.environ[param_name] = old_value
 
-    def test_basic_replication_flat_simple_with_multiple_root_datasets(self):
+    def test_basic_replication_flat_simple_with_multiple_root_datasets(self) -> None:
         self.setup_basic()
         param_name = bzfs.env_var_prefix + "reuse_ssh_connection"
         old_value = os.environ.get(param_name)
@@ -2142,7 +2142,7 @@ class LocalTestCase(BZFSTestCase):
             else:
                 os.environ[param_name] = old_value
 
-    def test_basic_replication_flat_simple_with_multiple_root_datasets_with_skip_on_error(self):
+    def test_basic_replication_flat_simple_with_multiple_root_datasets_with_skip_on_error(self) -> None:
         self.setup_basic()
         for i in range(0, 2):
             with stop_on_failure_subtest(i=i):
@@ -2166,7 +2166,7 @@ class LocalTestCase(BZFSTestCase):
                 else:
                     self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_basic_replication_flat_with_multiple_root_datasets_converted_from_recursive(self, volume=False):
+    def test_basic_replication_flat_with_multiple_root_datasets_converted_from_recursive(self, volume=False) -> None:
         self.assertTrue(dataset_exists(dst_root_dataset))
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.setup_basic(volume=volume)
@@ -2196,7 +2196,7 @@ class LocalTestCase(BZFSTestCase):
                     encryption_prop = dataset_property(dst_root_dataset + "/foo/a", "encryption")
                     self.assertEqual(encryption_prop, encryption_algo if self.is_encryption_mode() else "off")
 
-    def test_basic_replication_flat_send_recv_flags(self):
+    def test_basic_replication_flat_send_recv_flags(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("setting properties via zfs receive -o needs extra permissions")
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
@@ -2230,7 +2230,7 @@ class LocalTestCase(BZFSTestCase):
                     for name, value in props.items():
                         self.assertEqual(value, dataset_property(foo_a, name))
 
-    def test_basic_replication_recursive_with_exclude_dataset(self):
+    def test_basic_replication_recursive_with_exclude_dataset(self) -> None:
         self.assertTrue(dataset_exists(dst_root_dataset))
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.setup_basic()
@@ -2270,7 +2270,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertSnapshots(dst_root_dataset + "/moo", 1, "m")
                     self.assertSnapshots(dst_root_dataset + "/zoo", 1, "z")
 
-    def test_basic_replication_recursive_with_exclude_property(self):
+    def test_basic_replication_recursive_with_exclude_property(self) -> None:
         self.assertTrue(dataset_exists(dst_root_dataset))
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.setup_basic()
@@ -2318,7 +2318,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertSnapshots(dst_root_dataset + "/zoo", 1, "z")
                     self.assertSnapshots(dst_root_dataset + "/xoo", 1, "x")
 
-    def test_basic_replication_recursive_with_exclude_property_with_injected_dataset_deletes(self):
+    def test_basic_replication_recursive_with_exclude_property_with_injected_dataset_deletes(self) -> None:
         self.setup_basic()
         moo = create_filesystem(src_root_dataset, "moo")
         take_snapshot(moo, fix("m1"))
@@ -2338,7 +2338,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset))
         self.assertEqual(0, counter["zfs_list_exclude_property"])
 
-    def test_basic_replication_recursive_with_skip_on_error(self):
+    def test_basic_replication_recursive_with_skip_on_error(self) -> None:
         for j in range(0, 3):
             self.tearDownAndSetup()
             src_user1 = create_filesystem(src_root_dataset, "user1")
@@ -2416,7 +2416,7 @@ class LocalTestCase(BZFSTestCase):
                 self.assertSnapshots(dst_user2, 1, "v")
                 self.assertSnapshots(dst_user2_bar, 1, "b")
 
-    def test_basic_replication_flat_simple_using_main(self):
+    def test_basic_replication_flat_simple_using_main(self) -> None:
         self.setup_basic()
         with patch("sys.argv", ["bzfs.py", src_root_dataset, dst_root_dataset] + self.log_dir_opt()):
             bzfs.main()
@@ -2427,7 +2427,7 @@ class LocalTestCase(BZFSTestCase):
                 bzfs.main()
             self.assertEqual(e.exception.code, die_status)
 
-    def test_basic_replication_with_overlapping_datasets(self):
+    def test_basic_replication_with_overlapping_datasets(self) -> None:
         if self.param and self.param.get("ssh_mode", "local") not in ["local", "pull-push"]:
             self.skipTest("Test is only meaningful in local or pull-push mode")
         self.assertTrue(dataset_exists(src_root_dataset))
@@ -2440,7 +2440,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_bzfs(dst_root_dataset, dst_root_dataset + "/tmp", "--recursive", expected_status=die_status)
         self.run_bzfs(dst_root_dataset + "/tmp", dst_root_dataset, "--recursive", expected_status=die_status)
 
-    def test_max_command_line_bytes(self):
+    def test_max_command_line_bytes(self) -> None:
         job = cast(bzfs.Job, self.run_bzfs(src_root_dataset, dst_root_dataset, "--skip-replication"))
         self.assertTrue(job.get_max_command_line_bytes("dst", os_name="Linux") > 0)
         self.assertTrue(job.get_max_command_line_bytes("dst", os_name="FreeBSD") > 0)
@@ -2449,7 +2449,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertTrue(job.get_max_command_line_bytes("dst", os_name="Windows") > 0)
         self.assertTrue(job.get_max_command_line_bytes("dst", os_name="unknown") > 0)
 
-    def test_zfs_set(self):
+    def test_zfs_set(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("setting properties via zfs receive -o needs extra permissions")
         job = cast(bzfs.Job, self.run_bzfs(src_root_dataset, dst_root_dataset, "--skip-replication"))
@@ -2460,7 +2460,7 @@ class LocalTestCase(BZFSTestCase):
         for name, value in props.items():
             self.assertEqual(value, dataset_property(dst_root_dataset, name))
 
-    def test_zfs_set_via_recv_o(self):
+    def test_zfs_set_via_recv_o(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("setting properties via zfs receive -o needs extra permissions")
         for i in range(0, 5):
@@ -2488,7 +2488,7 @@ class LocalTestCase(BZFSTestCase):
                 for name, value in props.items():
                     self.assertEqual(value, dataset_property(dst_root_dataset + "/foo", name))
 
-    def test_zfs_set_via_set_include(self):
+    def test_zfs_set_via_set_include(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("setting properties via zfs receive -o needs extra permissions")
         self.setup_basic()
@@ -2511,7 +2511,7 @@ class LocalTestCase(BZFSTestCase):
         else:
             return []
 
-    def test_zfs_recv_include_regex(self):
+    def test_zfs_recv_include_regex(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("setting properties via zfs receive -o needs extra permissions")
         self.setup_basic()
@@ -2540,7 +2540,7 @@ class LocalTestCase(BZFSTestCase):
         for name, _ in excluded_props.items():
             self.assertEqual("-", dataset_property(dst_root_dataset + "/foo", name))
 
-    def test_zfs_recv_include_regex_with_duplicate_o_and_x_names(self):
+    def test_zfs_recv_include_regex_with_duplicate_o_and_x_names(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("setting properties via zfs receive -o needs extra permissions")
         self.setup_basic()
@@ -2568,7 +2568,7 @@ class LocalTestCase(BZFSTestCase):
         for name, _ in excluded_props.items():
             self.assertEqual("-", dataset_property(dst_root_dataset + "/foo", name))
 
-    def test_preserve_recordsize(self):
+    def test_preserve_recordsize(self) -> None:
         if self.is_no_privilege_elevation():
             self.skipTest("setting properties via zfs receive -o needs extra permissions")
         for i in range(0, 2):
@@ -2591,17 +2591,17 @@ class LocalTestCase(BZFSTestCase):
                 expected = old_recordsize if i == 0 else new_recordsize
                 self.assertEqual(str(expected), dataset_property(dst_root_dataset + "/foo", "recordsize"))
 
-    def test_check_zfs_dataset_busy_without_force(self):
+    def test_check_zfs_dataset_busy_without_force(self) -> None:
         self.setup_basic()
         inject_params = {"is_zfs_dataset_busy": True}
         self.run_bzfs(src_root_dataset, dst_root_dataset, expected_status=die_status, inject_params=inject_params)
 
-    def test_check_zfs_dataset_busy_with_force(self):
+    def test_check_zfs_dataset_busy_with_force(self) -> None:
         self.setup_basic()
         inject_params = {"is_zfs_dataset_busy": True}
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--force", expected_status=die_status, inject_params=inject_params)
 
-    def test_periodic_job_locking(self):
+    def test_periodic_job_locking(self) -> None:
         if is_solaris_zfs():
             self.skipTest(
                 "On Solaris fcntl.flock() does not work quite as expected. Solaris grants the lock on both file "
@@ -2628,7 +2628,7 @@ class LocalTestCase(BZFSTestCase):
                 Path(lock_file).unlink(missing_ok=True)  # avoid accumulation of stale lock files
                 self.assertFalse(os.path.exists(lock_file))
 
-    def test_basic_replication_with_delegation_disabled(self):
+    def test_basic_replication_with_delegation_disabled(self) -> None:
         if not self.is_no_privilege_elevation():
             self.skipTest("Test requires --no-privilege-elevation")
         self.setup_basic()
@@ -2641,7 +2641,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_bzfs(src_root_dataset, dst_root_dataset, expected_status=die_status)
         run_cmd(sudo_cmd + ["zpool", "set", "delegation=on", dst_pool_name])
 
-    def test_regex_compilation_error(self):
+    def test_regex_compilation_error(self) -> None:
         self.run_bzfs(
             src_root_dataset,
             dst_root_dataset,
@@ -2650,7 +2650,7 @@ class LocalTestCase(BZFSTestCase):
             expected_status=die_status,
         )
 
-    def test_basic_replication_skip_missing_snapshots(self):
+    def test_basic_replication_skip_missing_snapshots(self) -> None:
         self.assertTrue(dataset_exists(src_root_dataset))
         destroy(dst_root_dataset)
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--skip-missing-snapshots=fail", expected_status=die_status)
@@ -2696,7 +2696,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_no_common_snapshot_basic(self):
+    def test_no_common_snapshot_basic(self) -> None:
         self.setup_basic()
         self.run_bzfs(
             src_root_dataset + "/foo",
@@ -2718,7 +2718,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo/b"))  # b/c src has no snapshots
 
-    def test_no_common_snapshot_with_conflicting_dst_snapshot(self):
+    def test_no_common_snapshot_with_conflicting_dst_snapshot(self) -> None:
         self.setup_basic()
         self.run_bzfs(
             src_root_dataset + "/foo",
@@ -2748,7 +2748,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo/b"))  # b/c src has no snapshots
 
-    def test_basic_replication_with_injected_dataset_deletes(self):
+    def test_basic_replication_with_injected_dataset_deletes(self) -> None:
         destroy(dst_root_dataset)
         self.setup_basic()
         self.assertTrue(dataset_exists(src_root_dataset))
@@ -2762,10 +2762,10 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset))
         self.assertEqual(0, counter["zfs_list_snapshot_dst"])
 
-    def test_basic_replication_flat_simple_with_sufficiently_many_retries_on_error_injection(self):
+    def test_basic_replication_flat_simple_with_sufficiently_many_retries_on_error_injection(self) -> None:
         self.basic_replication_flat_simple_with_retries_on_error_injection(retries=6, expected_status=0)
 
-    def test_basic_replication_flat_simple_with_insufficiently_many_retries_on_error_injection(self):
+    def test_basic_replication_flat_simple_with_insufficiently_many_retries_on_error_injection(self) -> None:
         self.basic_replication_flat_simple_with_retries_on_error_injection(retries=5, expected_status=1)
 
     def basic_replication_flat_simple_with_retries_on_error_injection(self, retries=0, expected_status=0):
@@ -2788,7 +2788,7 @@ class LocalTestCase(BZFSTestCase):
         if expected_status == 0:
             self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_basic_replication_flat_simple_with_retryable_run_tasks_error(self):
+    def test_basic_replication_flat_simple_with_retryable_run_tasks_error(self) -> None:
         self.setup_basic()
 
         # inject failures before this many tries. only after that succeed the operation
@@ -2803,7 +2803,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertEqual(0, counter["retryable_run_tasks"])
         self.assertEqual(0, len(snapshots(dst_root_dataset, max_depth=None)))
 
-    def test_basic_replication_recursive_simple_with_force_unmount(self):
+    def test_basic_replication_recursive_simple_with_force_unmount(self) -> None:
         if self.is_encryption_mode():
             self.skipTest("encryption key not loaded")
         self.setup_basic()
@@ -2827,7 +2827,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo/b"))  # b/c src has no snapshots
 
-    def test_basic_replication_flat_with_bookmarks0(self):
+    def test_basic_replication_flat_with_bookmarks0(self) -> None:
         if not are_bookmarks_enabled("src"):
             self.skipTest("ZFS has no bookmark feature")
         for j in range(0, 2):
@@ -2864,7 +2864,7 @@ class LocalTestCase(BZFSTestCase):
                         self.assertSnapshotNames(dst_root_dataset, ["a_minutely", "b_minutely", "c_minutely", "d_daily"])
                         self.assertBookmarkNames(src_root_dataset, ["a_minutely", "b_minutely", "c_minutely", "d_daily"])
 
-    def test_xbasic_replication_flat_with_bookmarks1(self):
+    def test_xbasic_replication_flat_with_bookmarks1(self) -> None:
         if not are_bookmarks_enabled("src"):
             self.skipTest("ZFS has no bookmark feature")
         take_snapshot(src_root_dataset, fix("d1"))
@@ -2899,7 +2899,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertSnapshotNames(dst_root_dataset, ["d1", "d2"])
                     self.assertBookmarkNames(src_root_dataset, ["d1", "d2"])
 
-    def test_basic_replication_flat_with_bookmarks2(self):
+    def test_basic_replication_flat_with_bookmarks2(self) -> None:
         if not are_bookmarks_enabled("src"):
             self.skipTest("ZFS has no bookmark feature")
         take_snapshot(src_root_dataset, fix("d1"))
@@ -2948,7 +2948,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertSnapshotNames(dst_root_dataset, ["d1", "d2"])
                     self.assertBookmarkNames(src_root_dataset, ["d1", "d2"])
 
-    def test_basic_replication_flat_with_bookmarks3(self):
+    def test_basic_replication_flat_with_bookmarks3(self) -> None:
         if not are_bookmarks_enabled("src"):
             self.skipTest("ZFS has no bookmark feature")
         take_snapshot(src_root_dataset, fix("d1"))
@@ -3001,7 +3001,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertSnapshotNames(dst_root_dataset, ["d1", "d2"])
                     self.assertBookmarkNames(src_root_dataset, ["d1", "d1h", "d2"])
 
-    def test_basic_replication_flat_with_bookmarks_already_exists(self):
+    def test_basic_replication_flat_with_bookmarks_already_exists(self) -> None:
         """check that run_bzfs works as usual even if the bookmark already exists"""
         if not are_bookmarks_enabled("src"):
             self.skipTest("ZFS has no bookmark feature")
@@ -3023,7 +3023,7 @@ class LocalTestCase(BZFSTestCase):
                     self.assertBookmarkNames(src_root_dataset, ["d1"])
                     self.assertSnapshotNames(dst_root_dataset, ["d1"])
 
-    def test_complex_replication_flat_with_no_create_bookmark(self):
+    def test_complex_replication_flat_with_no_create_bookmark(self) -> None:
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
         self.setup_basic()
         src_foo = build(src_root_dataset + "/foo")
@@ -3228,10 +3228,10 @@ class LocalTestCase(BZFSTestCase):
                 self.assertSnapshots(dst_root_dataset, 0)
                 self.assertSnapshots(dst_root_dataset + "/foo", 3, "t", offset=8)
 
-    def test_complex_replication_flat_use_bookmarks_with_volume(self):
+    def test_complex_replication_flat_use_bookmarks_with_volume(self) -> None:
         self.test_complex_replication_flat_use_bookmarks(volume=True)
 
-    def test_complex_replication_flat_use_bookmarks(self, volume=False):
+    def test_complex_replication_flat_use_bookmarks(self, volume=False) -> None:
         if not are_bookmarks_enabled("src"):
             self.skipTest("ZFS has no bookmark feature")
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo"))
@@ -3471,7 +3471,7 @@ class LocalTestCase(BZFSTestCase):
             take_snapshot(src_root_dataset, fix(f"s{j}"))
         run_cmd(f"sudo -n zfs unmount {src_root_dataset}".split())
 
-    def test_all_snapshots_are_fully_replicated_even_though_every_recv_is_interrupted_and_resumed(self):
+    def test_all_snapshots_are_fully_replicated_even_though_every_recv_is_interrupted_and_resumed(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         n = 4
@@ -3497,7 +3497,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset, n - 1, "s")
         self.assertGreater(max_iters, 2)
 
-    def test_send_full_no_resume_recv_with_resume_token_present(self):
+    def test_send_full_no_resume_recv_with_resume_token_present(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         for i in range(0, 2):
@@ -3516,7 +3516,7 @@ class LocalTestCase(BZFSTestCase):
                     self.run_bzfs(src_root_dataset, dst_root_dataset, "--no-resume-recv", retries=0)
                     self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_send_incr_no_resume_recv_with_resume_token_present(self):
+    def test_send_incr_no_resume_recv_with_resume_token_present(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         for i in range(0, 2):
@@ -3540,7 +3540,7 @@ class LocalTestCase(BZFSTestCase):
                     self.run_bzfs(src_root_dataset, dst_root_dataset, "--no-resume-recv", retries=0)
                     self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_send_incr_resume_recv(self):
+    def test_send_incr_resume_recv(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         for i in range(0, 4):
@@ -3591,7 +3591,7 @@ class LocalTestCase(BZFSTestCase):
                 self.assert_receive_resume_token(dst_root_dataset, exists=False)
                 self.assertSnapshots(dst_root_dataset, n - 1, "s")
 
-    def test_send_full_resume_recv(self):
+    def test_send_full_resume_recv(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         for i in range(0, 4):
@@ -3638,7 +3638,7 @@ class LocalTestCase(BZFSTestCase):
                 self.assert_receive_resume_token(dst_root_dataset, exists=False)
                 self.assertSnapshots(dst_root_dataset, 1, "s")
 
-    def test_compare_snapshot_lists_with_nonexisting_source(self):
+    def test_compare_snapshot_lists_with_nonexisting_source(self) -> None:
         destroy(src_root_dataset, recursive=True)
         self.run_bzfs(
             src_root_dataset,
@@ -3648,7 +3648,7 @@ class LocalTestCase(BZFSTestCase):
             expected_status=die_status,
         )
 
-    def test_compare_snapshot_lists(self):
+    def test_compare_snapshot_lists(self) -> None:
         def snapshot_list(_job, location=""):
             log_file = _job.params.log_params.log_file
             tsv_file = glob.glob(log_file[0 : log_file.rindex(".log")] + ".cmp/*.tsv")[0]
@@ -3895,7 +3895,7 @@ class LocalTestCase(BZFSTestCase):
                     else:
                         os.environ[param_name] = old_value
 
-    def test_delete_dst_datasets_with_missing_src_root(self):
+    def test_delete_dst_datasets_with_missing_src_root(self) -> None:
         destroy(src_root_dataset, recursive=True)
         recreate_filesystem(dst_root_dataset)
         for i in range(0, 3):
@@ -3912,7 +3912,7 @@ class LocalTestCase(BZFSTestCase):
                 else:
                     self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_delete_dst_datasets_recursive_with_dummy_src(self):
+    def test_delete_dst_datasets_recursive_with_dummy_src(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         for i in range(0, 3):
             with stop_on_failure_subtest(i=i):
@@ -3928,7 +3928,7 @@ class LocalTestCase(BZFSTestCase):
                 else:
                     self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_delete_dst_datasets_recursive_with_non_included_dataset(self):
+    def test_delete_dst_datasets_recursive_with_non_included_dataset(self) -> None:
         dst_foo1 = create_filesystem(dst_root_dataset, "foo1")
         dst_foo1a = create_filesystem(dst_foo1, "a")
         self.assertIsNotNone(dst_foo1a)
@@ -3949,7 +3949,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertTrue(dataset_exists(dst_root_dataset + "/foo1/a"))
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo2"))
 
-    def test_delete_dst_datasets_flat_nothing_todo(self):
+    def test_delete_dst_datasets_flat_nothing_todo(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         take_snapshot(create_filesystem(dst_root_dataset, "bar"), "b1")
         destroy(build(src_root_dataset + "/foo"), recursive=True)
@@ -3961,7 +3961,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertTrue(dataset_exists(dst_root_dataset + "/foo"))
         self.assertTrue(dataset_exists(dst_root_dataset + "/bar"))
 
-    def test_delete_dst_datasets_recursive1(self):
+    def test_delete_dst_datasets_recursive1(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         take_snapshot(create_filesystem(dst_root_dataset, "bar"), fix("b1"))
         take_snapshot(create_filesystem(dst_root_dataset, "zoo"), fix("z1"))
@@ -3975,7 +3975,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset + "/bar"))
         self.assertFalse(dataset_exists(dst_root_dataset + "/zoo"))
 
-    def test_delete_dst_datasets_with_exclude_regex1(self):
+    def test_delete_dst_datasets_with_exclude_regex1(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         take_snapshot(create_filesystem(dst_root_dataset, "bar"), fix("b1"))
         take_snapshot(create_filesystem(dst_root_dataset, "zoo"), fix("z1"))
@@ -3999,7 +3999,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertTrue(dataset_exists(dst_root_dataset + "/bar"))
         self.assertTrue(dataset_exists(dst_root_dataset + "/zoo"))
 
-    def test_delete_dst_datasets_with_exclude_regex2(self):
+    def test_delete_dst_datasets_with_exclude_regex2(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         take_snapshot(create_filesystem(dst_root_dataset, "bar"), fix("b1"))
         take_snapshot(create_filesystem(dst_root_dataset, "zoo"), fix("z1"))
@@ -4021,7 +4021,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset + "/bar"))
         self.assertTrue(dataset_exists(dst_root_dataset + "/zoo"))
 
-    def test_delete_dst_datasets_with_exclude_dataset(self):
+    def test_delete_dst_datasets_with_exclude_dataset(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         take_snapshot(create_filesystem(dst_root_dataset, "bar"), fix("b1"))
         take_snapshot(create_filesystem(dst_root_dataset, "zoo"), fix("z1"))
@@ -4051,7 +4051,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset + "/bar"))
         self.assertTrue(dataset_exists(dst_root_dataset + "/zoo"))
 
-    def test_delete_dst_datasets_and_empty_datasets(self):
+    def test_delete_dst_datasets_and_empty_datasets(self) -> None:
         create_filesystems("axe")
         create_filesystems("foo/a")
         create_filesystems("foo/a/b")
@@ -4112,7 +4112,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset + "/zoo"))
         self.assertTrue(dataset_exists(dst_root_dataset + "/boo"))
 
-    def test_delete_dst_snapshots_and_empty_datasets(self):
+    def test_delete_dst_snapshots_and_empty_datasets(self) -> None:
         create_filesystems("axe")
         create_filesystems("foo/a")
         create_filesystems("foo/a/b")
@@ -4144,7 +4144,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertFalse(dataset_exists(dst_root_dataset + "/zoo"))
         self.assertTrue(dataset_exists(dst_root_dataset + "/boo"))
 
-    def test_delete_empty_dst_datasets_with_excluded_children_having_snapshots(self):
+    def test_delete_empty_dst_datasets_with_excluded_children_having_snapshots(self) -> None:
         # Setup:
         # dst_root/parent       (policy-selected, no snapshots itself)
         # dst_root/parent/child_excluded (policy-excluded, HAS snapshots)
@@ -4180,7 +4180,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertTrue(dataset_exists(child_excluded_ds), "Excluded child with snapshot should remain")
         self.assertFalse(dataset_exists(child_included_ds), "Included empty child should be deleted")
 
-    def test_delete_dst_snapshots_nothing_todo(self):
+    def test_delete_dst_snapshots_nothing_todo(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         self.assertTrue(dataset_exists(src_root_dataset + "/foo/b"))
         self.assertEqual(0, len(snapshots(build(src_root_dataset + "/foo/b"))))
@@ -4190,7 +4190,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo/b"))
 
-    def test_delete_dst_bookmarks_flat_with_replication(self):
+    def test_delete_dst_bookmarks_flat_with_replication(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--delete-dst-snapshots=bookmarks")
         self.assertSnapshots(dst_root_dataset, 3, "s")
@@ -4198,7 +4198,7 @@ class LocalTestCase(BZFSTestCase):
             self.run_bzfs(bzfs.dummy_dataset, src_root_dataset, "--skip-replication", "--delete-dst-snapshots=bookmarks")
             self.assertBookmarkNames(src_root_dataset, [])
 
-    def test_delete_dst_snapshots_flat_with_replication_with_crosscheck(self):
+    def test_delete_dst_snapshots_flat_with_replication_with_crosscheck(self) -> None:
         self.setup_basic()
         for j in range(0, 2):
             for i in range(0, 3):
@@ -4232,7 +4232,7 @@ class LocalTestCase(BZFSTestCase):
                     else:
                         self.assertSnapshotNames(dst_root_dataset, [])
 
-    def test_delete_dst_snapshots_flat(self):
+    def test_delete_dst_snapshots_flat(self) -> None:
         for i in range(0, 2):
             with stop_on_failure_subtest(i=i):
                 if i > 0:
@@ -4279,7 +4279,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_delete_dst_bookmarks_flat(self):
+    def test_delete_dst_bookmarks_flat(self) -> None:
         if not are_bookmarks_enabled("src"):
             self.skipTest("ZFS has no bookmark feature")
         for i in range(0, 1):
@@ -4325,7 +4325,7 @@ class LocalTestCase(BZFSTestCase):
                 )
                 self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_delete_dst_snapshots_despite_same_name(self):
+    def test_delete_dst_snapshots_despite_same_name(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         destroy(snapshots(src_root_dataset)[2])
         destroy(snapshots(src_root_dataset)[0])
@@ -4340,7 +4340,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshotNames(dst_root_dataset, ["s2"])
 
-    def test_delete_dst_snapshots_recursive(self):
+    def test_delete_dst_snapshots_recursive(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         destroy(snapshots(src_root_dataset)[2])
         destroy(snapshots(src_root_dataset)[0])
@@ -4361,7 +4361,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertTrue(dataset_exists(dst_root_dataset + "/foo/a"))
         self.assertSnapshotNames(dst_root_dataset + "/foo/a", [])
 
-    def test_delete_dst_snapshots_recursive_with_delete_empty_dst_datasets(self):
+    def test_delete_dst_snapshots_recursive_with_delete_empty_dst_datasets(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         destroy(snapshots(src_root_dataset)[2])
         destroy(snapshots(src_root_dataset)[0])
@@ -4382,7 +4382,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshotNames(dst_root_dataset + "/foo", ["t1", "t3"])
         self.assertFalse(dataset_exists(dst_root_dataset + "/foo/a"))
 
-    def test_delete_dst_snapshots_recursive_with_dummy(self):
+    def test_delete_dst_snapshots_recursive_with_dummy(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         for i in range(0, 2):
             self.run_bzfs(
@@ -4400,7 +4400,7 @@ class LocalTestCase(BZFSTestCase):
                 self.assertSnapshots(dst_root_dataset + "/foo", 0)
                 self.assertSnapshots(dst_root_dataset + "/foo/a", 0)
 
-    def test_delete_dst_snapshots_recursive_with_delete_empty_dst_datasets_with_dummy(self):
+    def test_delete_dst_snapshots_recursive_with_delete_empty_dst_datasets_with_dummy(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         for i in range(0, 3):
             self.run_bzfs(
@@ -4418,7 +4418,7 @@ class LocalTestCase(BZFSTestCase):
             else:
                 self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_delete_dst_snapshots_flat_with_nonexisting_destination(self):
+    def test_delete_dst_snapshots_flat_with_nonexisting_destination(self) -> None:
         self.setup_basic()
         destroy(dst_root_dataset, recursive=True)
         self.run_bzfs(
@@ -4430,7 +4430,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_delete_dst_snapshots_recursive_with_injected_errors(self):
+    def test_delete_dst_snapshots_recursive_with_injected_errors(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         self.assertTrue(dataset_exists(dst_root_dataset))
 
@@ -4449,7 +4449,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertEqual(0, counter["zfs_delete_snapshot"])
         self.assertEqual(0, len(snapshots(dst_root_dataset, max_depth=None)))
 
-    def test_delete_dst_snapshots_recursive_with_injected_dataset_deletes(self):
+    def test_delete_dst_snapshots_recursive_with_injected_dataset_deletes(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         self.assertTrue(dataset_exists(dst_root_dataset))
 
@@ -4467,7 +4467,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertEqual(0, counter["zfs_list_delete_dst_snapshots"])
         self.assertFalse(dataset_exists(dst_root_dataset))
 
-    def test_rollback_dst_snapshots_flat_with_injected_recv_token1(self):
+    def test_rollback_dst_snapshots_flat_with_injected_recv_token1(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         take_snapshot(src_root_dataset, fix("s1"))
@@ -4488,7 +4488,7 @@ class LocalTestCase(BZFSTestCase):
         )
         self.assertSnapshotNames(dst_root_dataset, ["s1", "s3"])
 
-    def test_delete_dst_snapshots_flat_with_injected_recv_token1(self):
+    def test_delete_dst_snapshots_flat_with_injected_recv_token1(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         take_snapshot(src_root_dataset, fix("s1"))
@@ -4509,7 +4509,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_bzfs(src_root_dataset, dst_root_dataset)
         self.assertSnapshots(dst_root_dataset, 2, "s")
 
-    def test_delete_dst_snapshots_flat_with_injected_recv_token2(self):
+    def test_delete_dst_snapshots_flat_with_injected_recv_token2(self) -> None:
         if not is_zpool_recv_resume_feature_enabled_or_active():
             self.skipTest("No recv resume zfs feature is available")
         take_snapshot(src_root_dataset, fix("s1"))
@@ -4532,7 +4532,7 @@ class LocalTestCase(BZFSTestCase):
         self.run_bzfs(src_root_dataset, dst_root_dataset)
         self.assertSnapshots(dst_root_dataset, 4, "s")
 
-    def test_delete_dst_snapshots_flat_with_time_range_full(self):
+    def test_delete_dst_snapshots_flat_with_time_range_full(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         destroy(snapshots(src_root_dataset)[2])
         destroy(snapshots(src_root_dataset)[0])
@@ -4552,7 +4552,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo", 3, "t")
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
 
-    def test_delete_dst_snapshots_flat_with_time_range_empty(self):
+    def test_delete_dst_snapshots_flat_with_time_range_empty(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         destroy(snapshots(src_root_dataset)[2])
         destroy(snapshots(src_root_dataset)[0])
@@ -4572,7 +4572,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo", 3, "t")
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
 
-    def test_delete_dst_snapshots_with_excludes_flat_nothing_todo(self):
+    def test_delete_dst_snapshots_with_excludes_flat_nothing_todo(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         self.run_bzfs(
             src_root_dataset,
@@ -4587,7 +4587,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo", 3, "t")
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
 
-    def test_delete_dst_snapshots_with_excludes_flat(self):
+    def test_delete_dst_snapshots_with_excludes_flat(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         for snap in snapshots(src_root_dataset):
             destroy(snap)
@@ -4606,7 +4606,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo", 3, "t")
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
 
-    def test_delete_dst_snapshots_with_excludes_recursive(self):
+    def test_delete_dst_snapshots_with_excludes_recursive(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         for snap in snapshots(src_root_dataset):
             destroy(snap)
@@ -4631,7 +4631,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshotNames(dst_root_dataset + "/foo", ["t1"])
         self.assertSnapshotNames(dst_root_dataset + "/foo/a", ["u1", "u2", "u3"])
 
-    def test_delete_dst_snapshots_with_excludes_recursive_and_excluding_dataset_regex(self):
+    def test_delete_dst_snapshots_with_excludes_recursive_and_excluding_dataset_regex(self) -> None:
         self.setup_basic_with_recursive_replication_done()
         for snap in snapshots(src_root_dataset):
             destroy(snap)
@@ -4658,7 +4658,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertSnapshots(dst_root_dataset + "/foo", 3, "t")
         self.assertSnapshots(dst_root_dataset + "/foo/a", 3, "u")
 
-    def test_syslog(self):
+    def test_syslog(self) -> None:
         if "Ubuntu" not in platform.version():
             self.skipTest("It is sufficient to only test this on Ubuntu where syslog paths are well known")
         for i in range(0, 2):
@@ -4695,7 +4695,7 @@ class LocalTestCase(BZFSTestCase):
                             self.assertNotIn(" [T] ", line)
                 self.assertTrue(found_msg, "No bzfs syslog message was found")
 
-    def test_log_config_file_nonempty(self):
+    def test_log_config_file_nonempty(self) -> None:
         if "Ubuntu" not in platform.version():
             self.skipTest("It is sufficient to only test this on Ubuntu where syslog paths are well known")
         config_str = """
@@ -4793,7 +4793,7 @@ class LocalTestCase(BZFSTestCase):
             with open(os.path.join(output_dir, "log_config.json"), "w", encoding="utf-8") as fd:
                 fd.write(config_str.lstrip())
 
-    def test_log_config_file_empty(self):
+    def test_log_config_file_empty(self) -> None:
         if "Ubuntu" not in platform.version():
             self.skipTest("It is sufficient to only test this on Ubuntu where syslog paths are well known")
         config_str = """ "version": 1, "disable_existing_loggers": false, "foo": "${bar:}" """
@@ -4826,7 +4826,7 @@ class LocalTestCase(BZFSTestCase):
         finally:
             os.remove(tmpfile)
 
-    def test_log_config_file_error(self):
+    def test_log_config_file_error(self) -> None:
         if "Ubuntu" not in platform.version():
             self.skipTest("It is sufficient to only test this on Ubuntu where syslog paths are well known")
 
@@ -4861,7 +4861,7 @@ class LocalTestCase(BZFSTestCase):
                 "--skip-replication",
             )
 
-    def test_main(self):
+    def test_main(self) -> None:
         self.setup_basic()
         with self.assertRaises(SystemExit):
             bzfs.main()
@@ -4869,15 +4869,15 @@ class LocalTestCase(BZFSTestCase):
             bzfs.run_main(bzfs.argument_parser().parse_args(["xxxx", dst_root_dataset]))
         bzfs.run_main(bzfs.argument_parser().parse_args([src_root_dataset, dst_root_dataset]))
 
-    def test_program_name_must_not_contain_whitespace(self):
+    def test_program_name_must_not_contain_whitespace(self) -> None:
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--zfs-program=zfs zfs", expected_status=die_status)
 
-    def test_ssh_program_must_not_be_disabled_in_nonlocal_mode(self):
+    def test_ssh_program_must_not_be_disabled_in_nonlocal_mode(self) -> None:
         if not self.param or self.param.get("ssh_mode", "local") == "local" or ssh_program != "ssh":
             self.skipTest("ssh is only required in nonlocal mode")
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--ssh-program=" + bzfs.disable_prg, expected_status=die_status)
 
-    def test_cache_flat_simple(self):
+    def test_cache_flat_simple(self) -> None:
         if not is_cache_snapshots_enabled():
             self.skipTest("Cache not supported")
 
@@ -4942,7 +4942,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertEqual(2, job.num_cache_hits)
         self.assertEqual(0, job.num_cache_misses)
 
-    def test_cache_flat_simple_subset(self):
+    def test_cache_flat_simple_subset(self) -> None:
         if not is_cache_snapshots_enabled():
             self.skipTest("Cache not supported")
 
@@ -4977,7 +4977,7 @@ class LocalTestCase(BZFSTestCase):
         self.assertEqual(2, job.num_cache_hits)
         self.assertEqual(0, job.num_cache_misses)
 
-    def test_jobrunner_flat_simple(self):
+    def test_jobrunner_flat_simple(self) -> None:
         def run_jobrunner(*args, **kwargs):
             return self.run_bzfs(
                 *args,
@@ -5323,7 +5323,7 @@ class LocalTestCase(BZFSTestCase):
                     bzfs_jobrunner.main()
                 self.assertEqual(2, context.exception.code)
 
-    def test_jobrunner_flat_simple_with_empty_targets(self):
+    def test_jobrunner_flat_simple_with_empty_targets(self) -> None:
         def run_jobrunner(*args, **kwargs):
             return self.run_bzfs(
                 *args,
@@ -5415,26 +5415,26 @@ class LocalTestCase(BZFSTestCase):
 
 #############################################################################
 class MinimalRemoteTestCase(BZFSTestCase):
-    def test_basic_replication_flat_simple(self):
+    def test_basic_replication_flat_simple(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_flat_simple()
 
-    def test_basic_replication_recursive1(self):
+    def test_basic_replication_recursive1(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_recursive1()
 
-    def test_delete_dst_datasets_recursive_with_dummy_src(self):
+    def test_delete_dst_datasets_recursive_with_dummy_src(self) -> None:
         LocalTestCase(param=self.param).test_delete_dst_datasets_recursive_with_dummy_src()
 
-    def test_basic_replication_recursive_parallel(self):
+    def test_basic_replication_recursive_parallel(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_recursive_parallel()
 
-    def test_inject_unavailable_sudo(self):
+    def test_inject_unavailable_sudo(self) -> None:
         expected_error = die_status if os.geteuid() != 0 and not self.is_no_privilege_elevation() else 0
         self.inject_unavailable_program("inject_unavailable_sudo", expected_error=expected_error)
         self.tearDownAndSetup()
         expected_error = 1 if os.geteuid() != 0 and not self.is_no_privilege_elevation() else 0
         self.inject_unavailable_program("inject_failing_sudo", expected_error=expected_error)
 
-    def test_disabled_sudo(self):
+    def test_disabled_sudo(self) -> None:
         expected_status = 0
         if os.geteuid() != 0 and not self.is_no_privilege_elevation():
             expected_status = die_status
@@ -5466,54 +5466,54 @@ class MinimalRemoteTestCase(BZFSTestCase):
 #############################################################################
 class FullRemoteTestCase(MinimalRemoteTestCase):
 
-    def test_ssh_program_must_not_be_disabled_in_nonlocal_mode(self):
+    def test_ssh_program_must_not_be_disabled_in_nonlocal_mode(self) -> None:
         LocalTestCase(param=self.param).test_ssh_program_must_not_be_disabled_in_nonlocal_mode()
 
-    def test_basic_replication_flat_nothing_todo(self):
+    def test_basic_replication_flat_nothing_todo(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_flat_nothing_todo()
 
-    def test_basic_replication_without_source(self):
+    def test_basic_replication_without_source(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_without_source()
 
-    def test_complex_replication_flat_use_bookmarks(self):
+    def test_complex_replication_flat_use_bookmarks(self) -> None:
         LocalTestCase(param=self.param).test_complex_replication_flat_use_bookmarks()
 
-    def test_basic_replication_flat_send_recv_flags(self):
+    def test_basic_replication_flat_send_recv_flags(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_flat_send_recv_flags()
 
-    def test_basic_replication_flat_simple_with_multiple_root_datasets(self):
+    def test_basic_replication_flat_simple_with_multiple_root_datasets(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_flat_simple_with_multiple_root_datasets()
 
-    def test_basic_replication_dataset_with_spaces(self):
+    def test_basic_replication_dataset_with_spaces(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_dataset_with_spaces()
 
-    def test_basic_replication_flat_with_multiple_root_datasets_converted_from_recursive(self):
+    def test_basic_replication_flat_with_multiple_root_datasets_converted_from_recursive(self) -> None:
         LocalTestCase(param=self.param).test_basic_replication_flat_with_multiple_root_datasets_converted_from_recursive()
 
-    def test_zfs_set(self):
+    def test_zfs_set(self) -> None:
         LocalTestCase(param=self.param).test_zfs_set()
 
-    def test_zfs_set_via_recv_o(self):
+    def test_zfs_set_via_recv_o(self) -> None:
         LocalTestCase(param=self.param).test_zfs_set_via_recv_o()
 
-    def test_zfs_set_via_set_include(self):
+    def test_zfs_set_via_set_include(self) -> None:
         LocalTestCase(param=self.param).test_zfs_set_via_set_include()
 
-    def test_inject_src_pipe_fail(self):
+    def test_inject_src_pipe_fail(self) -> None:
         self.inject_pipe_error("inject_src_pipe_fail", expected_error=[1, die_status])
 
-    def test_inject_src_pipe_garble(self):
+    def test_inject_src_pipe_garble(self) -> None:
         if is_pv_at_least_1_9_0() and is_zfs_at_least_2_3_0():
             self.skipTest("workaround for zfs send-receive pipeline hang")
         self.inject_pipe_error("inject_src_pipe_garble")
 
-    def test_inject_dst_pipe_garble(self):
+    def test_inject_dst_pipe_garble(self) -> None:
         self.inject_pipe_error("inject_dst_pipe_garble")
 
-    def test_inject_src_send_error(self):
+    def test_inject_src_send_error(self) -> None:
         self.inject_pipe_error("inject_src_send_error")
 
-    def test_inject_dst_receive_error(self):
+    def test_inject_dst_receive_error(self) -> None:
         self.inject_pipe_error("inject_dst_receive_error", expected_error=2)
 
     def inject_pipe_error(self, flag, expected_error=1):
@@ -5534,61 +5534,61 @@ class FullRemoteTestCase(MinimalRemoteTestCase):
                 else:
                     self.assertSnapshots(dst_root_dataset, 3, "s")
 
-    def test_inject_unavailable_mbuffer(self):
+    def test_inject_unavailable_mbuffer(self) -> None:
         self.inject_unavailable_program("inject_unavailable_mbuffer")
         if self.param and self.param.get("ssh_mode") != "local" and self.param.get("min_pipe_transfer_size", -1) == 0:
             self.tearDownAndSetup()
             self.inject_unavailable_program("inject_failing_mbuffer", expected_error=1)
 
-    def test_inject_unavailable_ps(self):
+    def test_inject_unavailable_ps(self) -> None:
         self.inject_unavailable_program("inject_unavailable_ps")
 
-    def test_inject_unavailable_pv(self):
+    def test_inject_unavailable_pv(self) -> None:
         self.inject_unavailable_program("inject_unavailable_pv")
 
-    def test_inject_unavailable_sh(self):
+    def test_inject_unavailable_sh(self) -> None:
         self.inject_unavailable_program("inject_unavailable_sh")
         self.tearDownAndSetup()
         self.inject_unavailable_program("inject_failing_sh")
 
-    def test_inject_unavailable_zstd(self):
+    def test_inject_unavailable_zstd(self) -> None:
         self.inject_unavailable_program("inject_unavailable_zstd")
 
-    def test_inject_unavailable_zpool(self):
+    def test_inject_unavailable_zpool(self) -> None:
         self.inject_unavailable_program("inject_unavailable_zpool")
         self.tearDownAndSetup()
         self.inject_unavailable_program("inject_failing_zpool")
 
-    def test_inject_unavailable_ssh(self):
+    def test_inject_unavailable_ssh(self) -> None:
         if self.param and self.param.get("ssh_mode") != "local":
             self.inject_unavailable_program("inject_unavailable_" + ssh_program, expected_error=die_status)
             self.tearDownAndSetup()
             self.inject_unavailable_program("inject_failing_" + ssh_program, expected_error=die_status)
 
-    def test_inject_unavailable_zfs(self):
+    def test_inject_unavailable_zfs(self) -> None:
         self.inject_unavailable_program("inject_unavailable_zfs", expected_error=die_status)
         self.tearDownAndSetup()
         self.inject_unavailable_program("inject_failing_zfs", expected_error=die_status)
 
-    def test_disabled_mbuffer(self):
+    def test_disabled_mbuffer(self) -> None:
         self.inject_disabled_program("mbuffer")
 
-    def test_disabled_ps(self):
+    def test_disabled_ps(self) -> None:
         self.inject_disabled_program("ps")
 
-    def test_disabled_pv(self):
+    def test_disabled_pv(self) -> None:
         self.inject_disabled_program("pv")
 
-    def test_disabled_sh(self):
+    def test_disabled_sh(self) -> None:
         self.inject_disabled_program("shell")
 
-    def test_disabled_compression(self):
+    def test_disabled_compression(self) -> None:
         self.inject_disabled_program("compression")
 
-    def test_disabled_zpool(self):
+    def test_disabled_zpool(self) -> None:
         self.inject_disabled_program("zpool")
 
-    def test_ssh_master_check_keeps_tcp_connection_alive_with_replication_recursive(self):
+    def test_ssh_master_check_keeps_tcp_connection_alive_with_replication_recursive(self) -> None:
         self.setup_basic()
         self.run_bzfs(src_root_dataset, dst_root_dataset, "--recursive", control_persist_margin_secs=2**64)
         self.assertSnapshots(dst_root_dataset, 3, "s")

--- a/bzfs_tests/test_integrations.py
+++ b/bzfs_tests/test_integrations.py
@@ -33,7 +33,7 @@ import traceback
 import unittest
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Sequence, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Sequence, Union, Iterable, Callable, cast
 from unittest.mock import patch
 
 from bzfs_main import bzfs, bzfs_jobrunner
@@ -101,7 +101,7 @@ if getenv_bool("test_enable_sudo", True) and (os.geteuid() != 0 or platform.syst
 test_mode = getenv_any("test_mode", "")  # Consider toggling this when testing isolated code changes
 
 
-def suite():
+def suite() -> unittest.TestSuite:
     is_smoke_test = test_mode == "smoke"  # run only a small subset of tests
     is_functional_test = test_mode == "functional"  # run most tests but only in a single local config combination
     is_adhoc_test = test_mode == "adhoc"  # run only a few isolated changes
@@ -5648,7 +5648,11 @@ def fix(s: str) -> str:
     return afix + s + afix
 
 
-def natsorted(iterable, key=None, reverse=False) -> List:
+def natsorted(
+    iterable: Iterable[str],
+    key: Optional[Callable[[str], str]] = None,
+    reverse: bool = False,
+) -> List[str]:
     """
     Returns a new list containing all items from the iterable in ascending order.
     If `key` is specified, it will be used to extract a comparison key from each list element.
@@ -5659,7 +5663,7 @@ def natsorted(iterable, key=None, reverse=False) -> List:
         return sorted(iterable, key=lambda x: natsort_key(key(x)), reverse=reverse)
 
 
-def natsort_key(s: str):
+def natsort_key(s: str) -> Tuple[str, int, str]:
     """Sorts strings that may contain non-negative integers according to numerical value if any two strings
     have the same non-numeric prefix. Example: s1 < s3 < s10 < s10a < s10b"""
     match = re.fullmatch(r"(\D*)(\d*)(.*)", s)
@@ -5667,7 +5671,7 @@ def natsort_key(s: str):
         prefix, num, suffix = match.groups()
         num = int(num) if num else 0
         return prefix, num, suffix
-    return s, 0
+    return s, 0, ""
 
 
 def is_solaris_zfs_at_least_11_4_42() -> bool:

--- a/bzfs_tests/test_integrations.py
+++ b/bzfs_tests/test_integrations.py
@@ -193,12 +193,12 @@ def suite() -> unittest.TestSuite:
 #############################################################################
 class ParametrizedTestCase(unittest.TestCase):
 
-    def __init__(self, methodName="runTest", param=None):
+    def __init__(self, methodName: str = "runTest", param: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(methodName)
         self.param = param
 
     @staticmethod
-    def parametrize(testcase_klass, param=None):
+    def parametrize(testcase_klass: type, param: Optional[Dict[str, Any]] = None) -> unittest.TestSuite:
         testloader = unittest.TestLoader()
         testnames = testloader.getTestCaseNames(testcase_klass)
         suite = unittest.TestSuite()
@@ -210,7 +210,7 @@ class ParametrizedTestCase(unittest.TestCase):
 #############################################################################
 class BZFSTestCase(ParametrizedTestCase):
 
-    def setUp(self, pool_size_bytes: int = pool_size_bytes_default):
+    def setUp(self, pool_size_bytes: int = pool_size_bytes_default) -> None:
         global src_pool, dst_pool
         global src_root_dataset, dst_root_dataset
         global afix
@@ -245,14 +245,14 @@ class BZFSTestCase(ParametrizedTestCase):
             # print(f"test zpool features: {features}", file=sys.stderr)
 
     # zpool list -o name|grep '^wb_'|xargs -n 1 -r --verbose zpool destroy; rm -fr /tmp/tmp* /run/user/$UID/bzfs/
-    def tearDown(self):
+    def tearDown(self) -> None:
         pass  # tear down is deferred to next setup for easier debugging
 
-    def tearDownAndSetup(self):
+    def tearDownAndSetup(self) -> None:
         self.tearDown()
         self.setUp()
 
-    def setup_basic(self, volume=False) -> None:
+    def setup_basic(self, volume: bool = False) -> None:
         compression_props = ["-o", "compression=on"]
         encryption_props = ["-o", f"encryption={encryption_algo}"]
         if is_solaris_zfs():
@@ -275,7 +275,7 @@ class BZFSTestCase(ParametrizedTestCase):
         take_snapshot(src_foo_a, fix("u2"))
         take_snapshot(src_foo_a, fix("u3"))
 
-    def setup_basic_woo(self, w=1, q=0) -> None:
+    def setup_basic_woo(self, w: int = 1, q: int = 0) -> None:
         for i in range(w):
             src_woo = create_filesystem(src_root_dataset, f"woo{i}")
             take_snapshot(src_woo, fix("w1"))
@@ -596,10 +596,10 @@ class BZFSTestCase(ParametrizedTestCase):
         self.assertListEqual(expected_names, snap_names)
 
     def is_no_privilege_elevation(self) -> bool:
-        return self.param and self.param.get("no_privilege_elevation", False)
+        return bool(self.param and self.param.get("no_privilege_elevation", False))
 
     def is_encryption_mode(self) -> bool:
-        return self.param and self.param.get("encrypted_dataset", False)
+        return bool(self.param and self.param.get("encrypted_dataset", False))
 
     @staticmethod
     def properties_with_special_characters() -> Dict[str, str]:

--- a/bzfs_tests/test_jobrunner.py
+++ b/bzfs_tests/test_jobrunner.py
@@ -40,7 +40,7 @@ def suite() -> unittest.TestSuite:
 
 #############################################################################
 class TestHelperFunctions(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.job = bzfs_jobrunner.Job()
 
     def test_validate_type(self) -> None:
@@ -88,7 +88,7 @@ class TestHelperFunctions(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.job.validate_is_subset(["3"], "foo", "x", "y")
 
-    def _make_mock_socket(self, bind_side_effect=None) -> MagicMock:
+    def _make_mock_socket(self, bind_side_effect: Optional[Exception] = None) -> MagicMock:
         sock = MagicMock()
         sock.bind.side_effect = bind_side_effect
         sock.__enter__.return_value = sock
@@ -283,7 +283,7 @@ class TestValidation(unittest.TestCase):
 
 #############################################################################
 class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.job = bzfs_jobrunner.Job()
         self.log_mock = MagicMock()
         self.job.log = cast(Logger, self.log_mock)

--- a/bzfs_tests/test_jobrunner.py
+++ b/bzfs_tests/test_jobrunner.py
@@ -19,7 +19,7 @@ import signal
 import subprocess
 import unittest
 from subprocess import DEVNULL, PIPE
-from typing import Any, Dict, Union, cast
+from typing import Any, Dict, Union, Optional, List, Tuple, cast
 from logging import Logger
 from unittest.mock import patch, MagicMock
 
@@ -27,7 +27,7 @@ from bzfs_main import bzfs_jobrunner
 from bzfs_main.bzfs_jobrunner import die_status
 
 
-def suite():
+def suite() -> unittest.TestSuite:
     suite = unittest.TestSuite()
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestHelperFunctions))
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestValidation))
@@ -43,7 +43,7 @@ class TestHelperFunctions(unittest.TestCase):
     def setUp(self):
         self.job = bzfs_jobrunner.Job()
 
-    def test_validate_type(self):
+    def test_validate_type(self) -> None:
         self.job.validate_type("foo", str, "name")
         self.job.validate_type(123, int, "name")
         with self.assertRaises(SystemExit):
@@ -59,23 +59,23 @@ class TestHelperFunctions(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.job.validate_type(None, Union[str, int], "name")
 
-    def test_validate_non_empty_string(self):
+    def test_validate_non_empty_string(self) -> None:
         self.job.validate_non_empty_string("valid_string", "name")
         with self.assertRaises(SystemExit):
             self.job.validate_non_empty_string("", "name")
 
-    def test_validate_non_negative_int(self):
+    def test_validate_non_negative_int(self) -> None:
         self.job.validate_non_negative_int(1, "name")
         self.job.validate_non_negative_int(0, "name")
         with self.assertRaises(SystemExit):
             self.job.validate_non_negative_int(-1, "name")
 
-    def test_validate_true(self):
+    def test_validate_true(self) -> None:
         self.job.validate_true(1, "name")
         with self.assertRaises(SystemExit):
             self.job.validate_true(0, "name")
 
-    def test_validate_is_subset(self):
+    def test_validate_is_subset(self) -> None:
         self.job.validate_is_subset(["1"], ["1", "2"], "x", "y")
         self.job.validate_is_subset([], ["1", "2"], "x", "y")
         self.job.validate_is_subset([], [], "x", "y")
@@ -88,37 +88,37 @@ class TestHelperFunctions(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.job.validate_is_subset(["3"], "foo", "x", "y")
 
-    def _make_mock_socket(self, bind_side_effect=None):
+    def _make_mock_socket(self, bind_side_effect=None) -> MagicMock:
         sock = MagicMock()
         sock.bind.side_effect = bind_side_effect
         sock.__enter__.return_value = sock
         sock.__exit__.return_value = False
         return sock
 
-    def test_detect_loopback_address_ipv4_supported(self):
+    def test_detect_loopback_address_ipv4_supported(self) -> None:
         ipv4 = self._make_mock_socket()
         with patch("socket.socket", side_effect=[ipv4]) as socket_factory:
             self.assertEqual("127.0.0.1", bzfs_jobrunner.detect_loopback_address())
             self.assertEqual(1, socket_factory.call_count)
 
-    def test_detect_loopback_address_ipv6_fallback(self):
+    def test_detect_loopback_address_ipv6_fallback(self) -> None:
         ipv4_fail = self._make_mock_socket(OSError("No IPv4"))
         ipv6_ok = self._make_mock_socket()
         with patch("socket.socket", side_effect=[ipv4_fail, ipv6_ok]) as socket_factory:
             self.assertEqual("::1", bzfs_jobrunner.detect_loopback_address())
             self.assertEqual(2, socket_factory.call_count)
 
-    def test_detect_loopback_address_neither_supported(self):
+    def test_detect_loopback_address_neither_supported(self) -> None:
         ipv4_fail = self._make_mock_socket(OSError("No IPv4"))
         ipv6_fail = self._make_mock_socket(OSError("No IPv6"))
         with patch("socket.socket", side_effect=[ipv4_fail, ipv6_fail]) as socket_factory:
             self.assertEqual("", bzfs_jobrunner.detect_loopback_address())
             self.assertEqual(2, socket_factory.call_count)
 
-    def test_pretty_print_formatter(self):
+    def test_pretty_print_formatter(self) -> None:
         self.assertIsNotNone(str(bzfs_jobrunner.pretty_print_formatter({"foo": "bar"})))
 
-    def test_help(self):
+    def test_help(self) -> None:
         if is_solaris_zfs():
             self.skipTest("FIXME: BlockingIOError: [Errno 11] write could not complete without blocking")
         parser = bzfs_jobrunner.argument_parser()
@@ -126,36 +126,36 @@ class TestHelperFunctions(unittest.TestCase):
             parser.parse_args(["--help"])
         self.assertEqual(0, e.exception.code)
 
-    def test_version(self):
+    def test_version(self) -> None:
         parser = bzfs_jobrunner.argument_parser()
         with self.assertRaises(SystemExit) as e:
             parser.parse_args(["--version"])
         self.assertEqual(0, e.exception.code)
 
-    def test_sorted_dict_empty_dictionary_returns_empty(self):
+    def test_sorted_dict_empty_dictionary_returns_empty(self) -> None:
         result: Dict[str, int] = bzfs_jobrunner.sorted_dict({})
         self.assertEqual(result, {})
 
-    def test_sorted_dict_single_key_value_pair_is_sorted_correctly(self):
+    def test_sorted_dict_single_key_value_pair_is_sorted_correctly(self) -> None:
         result: Dict[str, int] = bzfs_jobrunner.sorted_dict({"a": 1})
         self.assertEqual(result, {"a": 1})
 
-    def test_sorted_dict_multiple_key_value_pairs_are_sorted_by_keys(self):
+    def test_sorted_dict_multiple_key_value_pairs_are_sorted_by_keys(self) -> None:
         result: Dict[str, int] = bzfs_jobrunner.sorted_dict({"b": 2, "a": 1, "c": 3})
         self.assertEqual(result, {"a": 1, "b": 2, "c": 3})
 
-    def test_sorted_dict_with_numeric_keys_is_sorted_correctly(self):
+    def test_sorted_dict_with_numeric_keys_is_sorted_correctly(self) -> None:
         result: Dict[int, str] = bzfs_jobrunner.sorted_dict({3: "three", 1: "one", 2: "two"})
         self.assertEqual(result, {1: "one", 2: "two", 3: "three"})
 
-    def test_sorted_dict_with_mixed_key_types_raises_error(self):
+    def test_sorted_dict_with_mixed_key_types_raises_error(self) -> None:
         with self.assertRaises(TypeError):
             bzfs_jobrunner.sorted_dict({"a": 1, 2: "two"})
 
 
 #############################################################################
 class TestValidation(unittest.TestCase):
-    def test_multisource_substitution_token_validation_with_empty_target(self):
+    def test_multisource_substitution_token_validation_with_empty_target(self) -> None:
         job = bzfs_jobrunner.Job()
         job.log = cast(Any, MagicMock())
         job.is_test_mode = True
@@ -198,7 +198,7 @@ class TestValidation(unittest.TestCase):
             self.assertEqual(die_status, cm.exception.code)
             self.assertIn(expect_msg, str(cm.exception))
 
-    def test_multisource_substitution_token_validation_passes_safe_config(self):
+    def test_multisource_substitution_token_validation_passes_safe_config(self) -> None:
         job = bzfs_jobrunner.Job()
         job.log = cast(Any, MagicMock())
         job.is_test_mode = True
@@ -235,7 +235,7 @@ class TestValidation(unittest.TestCase):
                     job.run_main(base_argv_safe)  # Should not raise SystemExit
                     mock_run_subjobs_2.assert_called_once()
 
-    def test_multisource_substitution_token_validation_rejects_unsafe_config(self):
+    def test_multisource_substitution_token_validation_rejects_unsafe_config(self) -> None:
         job = bzfs_jobrunner.Job()
         job.log = cast(Any, MagicMock())
         job.is_test_mode = True
@@ -288,12 +288,12 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.log_mock = MagicMock()
         self.job.log = cast(Logger, self.log_mock)
 
-    def test_empty_input_raises(self):
+    def test_empty_input_raises(self) -> None:
         with self.assertRaises(AssertionError):
             self.job.skip_nonexisting_local_dst_pools([])
 
     @patch("subprocess.run")
-    def test_single_existing_pool(self, mock_run):
+    def test_single_existing_pool(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool1\n", stderr="")
         pairs = [("-:srcpool1/src1", "-:dstpool1/dst1")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -304,7 +304,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         mock_run.assert_called_once_with(expected_cmd, stdin=DEVNULL, stdout=PIPE, stderr=PIPE, text=True)
 
     @patch("subprocess.run")
-    def test_single_nonexisting_pool(self, mock_run):
+    def test_single_nonexisting_pool(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
         pairs = [("-:srcpool2/src2", "-:dstpool2/dst2")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -316,7 +316,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         )
 
     @patch("subprocess.run")
-    def test_multiple_pools_mixed(self, mock_run):
+    def test_multiple_pools_mixed(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool1\n", stderr="")
         pairs = [
             ("srcpool1/src1", "-:dstpool1/dst1"),
@@ -332,7 +332,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         )
 
     @patch("subprocess.run")
-    def test_caching_avoids_subprocess_run(self, mock_run):
+    def test_caching_avoids_subprocess_run(self, mock_run: MagicMock) -> None:
         self.job.cache_existing_dst_pools = {"-:dstpool1"}
         self.job.cache_known_dst_pools = {"-:dstpool1", "-:dstpool2"}
         pairs = [("srcpool1/src1", "-:dstpool1/dst1"), ("srcpool2/src2", "-:dstpool2/dst2")]
@@ -344,7 +344,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         )
 
     @patch("subprocess.run")
-    def test_multiple_pools_exist_returns_all(self, mock_run):
+    def test_multiple_pools_exist_returns_all(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool1\ndstpool2\n", stderr="")
         pairs = [("srcpool1/src1", "-:dstpool1/dst1"), ("srcpool2/src2", "-:dstpool2/dst2")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -354,7 +354,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         mock_run.assert_called_once()
 
     @patch("subprocess.run")
-    def test_repeated_call_caching(self, mock_run):
+    def test_repeated_call_caching(self, mock_run: MagicMock) -> None:
         mock_run.side_effect = [
             subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool1\n", stderr=""),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool3\n", stderr=""),
@@ -368,7 +368,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.assertEqual(2, mock_run.call_count)
 
     @patch("subprocess.run")
-    def test_multislash_dataset_names(self, mock_run):
+    def test_multislash_dataset_names(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool1\n", stderr="")
         pairs = [("srcpool1/src1", "-:dstpool1/child/grand")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -376,7 +376,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.assertIn("-:dstpool1", self.job.cache_existing_dst_pools)
 
     @patch("subprocess.run")
-    def test_multiple_warnings_for_nonexistent(self, mock_run):
+    def test_multiple_warnings_for_nonexistent(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
         pairs = [("srcpool1/src1", "-:srcpool1/dst1"), ("srcpool2/src2", "-:dstpool2/dst2")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -388,7 +388,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.assertEqual(expected_calls, self.log_mock.warning.mock_calls)
 
     @patch("subprocess.run")
-    def test_duplicate_pool_input(self, mock_run):
+    def test_duplicate_pool_input(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool1\n", stderr="")
         pairs = [("srcpool1/src1", "-:dstpool1/dst1"), ("srcpool2/src2", "-:dstpool1/dst2")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -397,7 +397,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
 
     # dst without slash, existing pool
     @patch("subprocess.run")
-    def test_dst_without_slash_existing_pool(self, mock_run):
+    def test_dst_without_slash_existing_pool(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dstpool4\n", stderr="")
         pairs = [("srcpool4/src4", "-:dstpool4")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -409,7 +409,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
 
     # dst without slash, non-existing pool
     @patch("subprocess.run")
-    def test_dst_without_slash_nonexisting_pool(self, mock_run):
+    def test_dst_without_slash_nonexisting_pool(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
         pairs = [("srcpool4/src4", "-:dstpool2")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -422,7 +422,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
 
     # non-local dst and without slash
     @patch("subprocess.run")
-    def test_nonlocaldst_without_slash(self, mock_run):
+    def test_nonlocaldst_without_slash(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
         pairs = [("srcpool4/src4", "127.0.0.1:dstpool2")]
         result = self.job.skip_nonexisting_local_dst_pools(pairs)
@@ -432,7 +432,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.assertEqual([], self.log_mock.warning.mock_calls)
 
     @patch("subprocess.run")
-    def test_mixed_local_existing_and_remote(self, mock_run):
+    def test_mixed_local_existing_and_remote(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="local1\n", stderr="")
         pairs = [
             ("srcpool4/src1", "-:local1/src1"),  # Local, should be checked and found
@@ -447,7 +447,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.log_mock.warning.assert_not_called()
 
     @patch("subprocess.run")
-    def test_mixed_local_nonexisting_and_remote(self, mock_run):
+    def test_mixed_local_nonexisting_and_remote(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")  # local2 nonexistng
         pairs = [
             ("src1/src1", "-:local2/src1"),  # Local, should be checked and NOT found
@@ -466,7 +466,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         )
 
     @patch("subprocess.run")
-    def test_mixed_local_existing_nonexisting_and_remote(self, mock_run):
+    def test_mixed_local_existing_nonexisting_and_remote(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="local1\n", stderr=""
         )  # local1 exists, local2 does not
@@ -496,7 +496,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         )
 
     @patch("subprocess.run")
-    def test_all_remote_pools(self, mock_run):
+    def test_all_remote_pools(self, mock_run: MagicMock) -> None:
         pairs = [
             ("src1/src1", "remote1:pool1/src1"),
             ("src2/src2", "remote2:pool2/src2"),
@@ -509,7 +509,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.log_mock.warning.assert_not_called()
 
     @patch("subprocess.run")
-    def unexpected_error_on_local_dst_pool_check_raises_exception(self, mock_subprocess_run):
+    def unexpected_error_on_local_dst_pool_check_raises_exception(self, mock_subprocess_run: MagicMock) -> None:
         mock_subprocess_run.return_value = subprocess.CompletedProcess(
             args=["zfs", "list", "-t", "filesystem,volume", "-Hp", "-o", "name"],
             returncode=2,
@@ -522,7 +522,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         self.assertIn("Unexpected error 2 on checking for existing local dst pools: Permission denied", str(cm.exception))
 
     @patch("subprocess.run")
-    def local_dst_pool_not_found_skips_dataset(self, mock_subprocess_run):
+    def local_dst_pool_not_found_skips_dataset(self, mock_subprocess_run: MagicMock) -> None:
         mock_subprocess_run.return_value = subprocess.CompletedProcess(
             args=["zfs", "list", "-t", "filesystem,volume", "-Hp", "-o", "name"],
             returncode=1,
@@ -536,7 +536,7 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
         )
 
     @patch("subprocess.run")
-    def local_dst_pool_exists_processes_dataset(self, mock_subprocess_run):
+    def local_dst_pool_exists_processes_dataset(self, mock_subprocess_run: MagicMock) -> None:
         mock_subprocess_run.return_value = subprocess.CompletedProcess(
             args=["zfs", "list", "-t", "filesystem,volume", "-Hp", "-o", "name"],
             returncode=0,
@@ -550,45 +550,45 @@ class TestSkipDatasetsWithNonExistingDstPool(unittest.TestCase):
 #############################################################################
 class TestRunSubJobSpawnProcessPerJob(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.assertIsNotNone(shutil.which("sh"))
         self.job = bzfs_jobrunner.Job()
 
-    def run_and_capture(self, cmd, timeout_secs):
+    def run_and_capture(self, cmd: List[str], timeout_secs: Optional[float]) -> Tuple[Optional[int], List[str]]:
         """
         Helper: invoke the method, return (exit_code, [all error‑log messages]).
         """
         with patch.object(self.job.log, "error") as mock_error:
             code = self.job.run_worker_job_spawn_process_per_job(cmd, timeout_secs=timeout_secs)
-            logs = [call.args[1] for call in mock_error.call_args_list]
+            logs = [cast(str, call.args[1]) for call in mock_error.call_args_list]
         return code, logs
 
-    def test_normal_completion(self):
+    def test_normal_completion(self) -> None:
         """Exits 0 under timeout, no errors."""
         code, logs = self.run_and_capture(["sleep", "0"], timeout_secs=1.0)
         self.assertEqual(0, code)
         self.assertListEqual([], logs)
 
-    def test_none_timeout(self):
+    def test_none_timeout(self) -> None:
         """timeout_secs=None -> wait indefinitely, no errors."""
         code, logs = self.run_and_capture(["sleep", "0"], timeout_secs=None)
         self.assertEqual(0, code)
         self.assertListEqual([], logs)
 
-    def test_nonzero_exit(self):
+    def test_nonzero_exit(self) -> None:
         """Non‑zero exit code is propagated, no errors logged."""
         code, logs = self.run_and_capture(["sh", "-c", "exit 3"], timeout_secs=1.0)
         self.assertEqual(3, code)
         self.assertListEqual([], logs)
 
-    def test_dryrun(self):
+    def test_dryrun(self) -> None:
         """dryrun mode does not actually execute the CLI command."""
         self.job.jobrunner_dryrun = True
         code, logs = self.run_and_capture(["sh", "-c", "exit 3"], timeout_secs=None)
         self.assertEqual(0, code)
         self.assertListEqual([], logs)
 
-    def test_timeout_terminate(self):
+    def test_timeout_terminate(self) -> None:
         """Timeout->SIGTERM path: return code and first log prefix."""
         code, logs = self.run_and_capture(["sleep", "1"], timeout_secs=0.1)
         self.assertEqual(-signal.SIGTERM, code)
@@ -597,7 +597,7 @@ class TestRunSubJobSpawnProcessPerJob(unittest.TestCase):
             f"Expected first log starting with 'Terminating worker job', got {logs!r}",
         )
 
-    def test_timeout_kill(self):
+    def test_timeout_kill(self) -> None:
         """SIGTERM ignored→SIGKILL path: return code and kill‐log present."""
         code, logs = self.run_and_capture(["sh", "-c", 'trap "" TERM; sleep 1'], timeout_secs=0.1)
         self.assertEqual(-signal.SIGKILL, code)
@@ -610,41 +610,41 @@ class TestRunSubJobSpawnProcessPerJob(unittest.TestCase):
 #############################################################################
 @patch("bzfs_main.bzfs_jobrunner.Job._bzfs_run_main")
 class TestRunSubJobInCurrentThread(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.job = bzfs_jobrunner.Job()
 
-    def test_no_timeout_success(self, mock_bzfs_run_main):
+    def test_no_timeout_success(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs", "foo", "bar"]
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
         self.assertEqual(0, result)
         mock_bzfs_run_main.assert_called_once_with(cmd)
 
-    def test_timeout_flag_insertion(self, mock_bzfs_run_main):
+    def test_timeout_flag_insertion(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs", "foo"]
         timeout = 1.234
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=timeout)
         self.assertEqual(0, result)
         mock_bzfs_run_main.assert_called_once_with(["bzfs", "--timeout=1234milliseconds", "foo"])
 
-    def test_called_process_error_returns_returncode(self, mock_bzfs_run_main):
+    def test_called_process_error_returns_returncode(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs", "foo"]
         mock_bzfs_run_main.side_effect = subprocess.CalledProcessError(returncode=7, cmd=cmd)
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
         self.assertEqual(7, result)
 
-    def test_system_exit_with_code(self, mock_bzfs_run_main):
+    def test_system_exit_with_code(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs", "foo"]
         mock_bzfs_run_main.side_effect = SystemExit(3)
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
         self.assertEqual(3, result)
 
-    def test_system_exit_without_code(self, mock_bzfs_run_main):
+    def test_system_exit_without_code(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs", "foo"]
         mock_bzfs_run_main.side_effect = SystemExit
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
         self.assertIsNone(result)
 
-    def test_dryrun(self, mock_bzfs_run_main):
+    def test_dryrun(self, mock_bzfs_run_main: MagicMock) -> None:
         """dryrun mode does not actually execute the CLI command."""
         self.job.jobrunner_dryrun = True
         cmd = ["bzfs", "foo"]
@@ -652,19 +652,19 @@ class TestRunSubJobInCurrentThread(unittest.TestCase):
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
         self.assertEqual(0, result)
 
-    def test_generic_exception_returns_die_status(self, mock_bzfs_run_main):
+    def test_generic_exception_returns_die_status(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs", "foo"]
         mock_bzfs_run_main.side_effect = SystemExit(die_status)
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
         self.assertEqual(die_status, result)
 
-    def test_single_element_cmd_edge(self, mock_bzfs_run_main):
+    def test_single_element_cmd_edge(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs"]
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
         self.assertEqual(0, result)
         mock_bzfs_run_main.assert_called_once_with(cmd)
 
-    def test_unexpected_exception(self, mock_bzfs_run_main):
+    def test_unexpected_exception(self, mock_bzfs_run_main: MagicMock) -> None:
         cmd = ["bzfs", "foo"]
         mock_bzfs_run_main.side_effect = ValueError
         result = self.job.run_worker_job_in_current_thread(cmd.copy(), timeout_secs=None)
@@ -673,16 +673,16 @@ class TestRunSubJobInCurrentThread(unittest.TestCase):
 
 #############################################################################
 class TestRunSubJob(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.job = bzfs_jobrunner.Job()
         self.job.stats.jobs_all = 1
         self.assertIsNone(self.job.first_exception)
 
-    def test_success(self):
+    def test_success(self) -> None:
         result = self.job.run_subjob(cmd=["true"], name="j0", timeout_secs=None, spawn_process_per_job=True)
         self.assertEqual(0, result)
 
-    def test_failure(self):
+    def test_failure(self) -> None:
         self.job.stats.jobs_all = 2
         result = self.job.run_subjob(cmd=["false"], name="j0", timeout_secs=None, spawn_process_per_job=True)
         self.assertNotEqual(0, result)
@@ -694,14 +694,14 @@ class TestRunSubJob(unittest.TestCase):
         self.assertIsInstance(self.job.first_exception, int)
         self.assertTrue(self.job.first_exception != 0)
 
-    def test_timeout(self):
+    def test_timeout(self) -> None:
         self.job.stats.jobs_all = 2
         result = self.job.run_subjob(cmd=["sleep", "0"], name="j0", timeout_secs=1, spawn_process_per_job=True)
         self.assertEqual(0, result)
         result = self.job.run_subjob(cmd=["sleep", "1"], name="j1", timeout_secs=0.01, spawn_process_per_job=True)
         self.assertNotEqual(0, result)
 
-    def test_nonexisting_cmd(self):
+    def test_nonexisting_cmd(self) -> None:
         with self.assertRaises(FileNotFoundError):
             self.job.run_subjob(cmd=["sleep_nonexisting_cmd", "1"], name="j0", timeout_secs=None, spawn_process_per_job=True)
 

--- a/bzfs_tests/test_utils.py
+++ b/bzfs_tests/test_utils.py
@@ -18,7 +18,7 @@ import unittest
 from bzfs_main import utils
 
 
-def suite():
+def suite() -> unittest.TestSuite:
     suite = unittest.TestSuite()
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestBzfsUtils))
     return suite
@@ -27,25 +27,25 @@ def suite():
 #############################################################################
 class TestBzfsUtils(unittest.TestCase):
 
-    def test_cut_field1(self):
+    def test_cut_field1(self) -> None:
         lines = ["a\tb\tc", "d\te\tf"]
         expected = ["a", "d"]
         self.assertEqual(utils.cut(field=1, lines=lines), expected)
 
-    def test_cut_field2(self):
+    def test_cut_field2(self) -> None:
         lines = ["a\tb\tc", "d\te\tf"]
         expected = ["b\tc", "e\tf"]
         self.assertEqual(utils.cut(field=2, lines=lines), expected)
 
-    def test_cut_invalid_field(self):
+    def test_cut_invalid_field(self) -> None:
         lines = ["a\tb\tc"]
         with self.assertRaises(ValueError):
             utils.cut(field=3, lines=lines)
 
-    def test_cut_empty_lines(self):
+    def test_cut_empty_lines(self) -> None:
         self.assertEqual(utils.cut(field=1, lines=[]), [])
 
-    def test_cut_different_separator(self):
+    def test_cut_different_separator(self) -> None:
         lines = ["a,b,c", "d,e,f"]
         expected = ["a", "d"]
         self.assertEqual(utils.cut(field=1, separator=",", lines=lines), expected)

--- a/bzfs_tests/zfs_util.py
+++ b/bzfs_tests/zfs_util.py
@@ -16,7 +16,7 @@
 import platform
 import re
 import subprocess
-from typing import List, Mapping, Optional, Sequence, Union
+from typing import List, Mapping, Optional, Sequence, Union, cast
 
 sudo_cmd = []
 
@@ -161,7 +161,7 @@ def create_filesystem(
 
 
 def datasets(dataset: str) -> List[str]:
-    return zfs_list([dataset], types=["filesystem", "volume"], max_depth=1)[1:]
+    return cast(List[str], zfs_list([dataset], types=["filesystem", "volume"], max_depth=1))[1:]
 
 
 def take_snapshot(
@@ -184,7 +184,7 @@ def take_snapshot(
 
 
 def snapshots(dataset: str, max_depth: Optional[int] = 1) -> List[str]:
-    return zfs_list([dataset], types=["snapshot"], max_depth=max_depth)
+    return cast(List[str], zfs_list([dataset], types=["snapshot"], max_depth=max_depth))
 
 
 def create_bookmark(dataset: str, snapshot_tag: str, bookmark_tag: str) -> str:
@@ -195,7 +195,7 @@ def create_bookmark(dataset: str, snapshot_tag: str, bookmark_tag: str) -> str:
 
 
 def bookmarks(dataset: str, max_depth: int = 1) -> List[str]:
-    return zfs_list([dataset], types=["bookmark"], max_depth=max_depth)
+    return cast(List[str], zfs_list([dataset], types=["bookmark"], max_depth=max_depth))
 
 
 def snapshot_name(snapshot: str) -> str:
@@ -207,14 +207,14 @@ def bookmark_name(bookmark: str) -> str:
 
 
 def dataset_property(dataset: str, prop: str) -> str:
-    return zfs_list([dataset], props=[prop], types=["filesystem", "volume"], max_depth=0, splitlines=False)
+    return cast(str, zfs_list([dataset], props=[prop], types=["filesystem", "volume"], max_depth=0, splitlines=False))
     # return zfs_get(
     #     [dataset], props=[prop], types=["filesystem", "volume"], max_depth=0, fields=["value"], splitlines=False
     # )
 
 
 def snapshot_property(snapshot: str, prop: str) -> str:
-    return zfs_list([snapshot], props=[prop], types=["snapshot"], max_depth=0, splitlines=False)
+    return cast(str, zfs_list([snapshot], props=[prop], types=["snapshot"], max_depth=0, splitlines=False))
 
 
 def zfs_list(
@@ -225,7 +225,7 @@ def zfs_list(
     parsable: bool = True,
     sort_props: Optional[List[str]] = None,
     splitlines: bool = True,
-):
+) -> Union[List[str], str]:
     cmd = ["zfs", "list"]
     if names is None:
         names = []
@@ -271,7 +271,7 @@ def zfs_get(
     fields: Optional[List[str]] = None,
     sources: Optional[List[str]] = None,
     splitlines: bool = True,
-):
+) -> Union[List[str], str]:
     cmd = ["zfs", "get"]
     if names is None:
         names = []

--- a/bzfs_tests/zfs_util.py
+++ b/bzfs_tests/zfs_util.py
@@ -16,7 +16,7 @@
 import platform
 import re
 import subprocess
-from typing import List, Mapping, Optional, Union
+from typing import List, Mapping, Optional, Sequence, Union
 
 sudo_cmd = []
 
@@ -169,7 +169,7 @@ def take_snapshot(dataset: str, snapshot_tag: str, recursive=False, props=[]) ->
     return snapshot
 
 
-def snapshots(dataset: str, max_depth: int = 1) -> List[str]:
+def snapshots(dataset: str, max_depth: Optional[int] = 1) -> List[str]:
     return zfs_list([dataset], types=["snapshot"], max_depth=max_depth)
 
 
@@ -397,6 +397,7 @@ def is_solaris_zfs() -> bool:
     return platform.system() == "SunOS"
 
 
-def run_cmd(*params, splitlines=True):
-    stdout = subprocess.run(*params, stdout=subprocess.PIPE, text=True, check=True).stdout
-    return stdout.splitlines() if splitlines else stdout[0:-1]  # omit trailing newline char
+def run_cmd(cmd: Sequence[str], splitlines: bool = True) -> Union[List[str], str]:
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, text=True, check=True)
+    stdout = result.stdout or ""
+    return stdout.splitlines() if splitlines else stdout[:-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ select = ["E", "F", "A", "B"]  # Or use ["ALL"] if you want every check enabled
 
 [tool.mypy]
 python_version = "3.8"
-#check_untyped_defs = true
+check_untyped_defs = true
 disable_error_code = [
 #  "assignment",
 #  "attr-defined",


### PR DESCRIPTION
## Summary
- adjust integration tests to remove erroneous return-type uses
- cast to concrete Job type when accessing Job-specific methods
- ensure cleanup operations only run when datasets exist

## Testing
- `pre-commit run --files bzfs_tests/test_integrations.py`
- `bzfs_test_mode=unit ./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68440ab2ba68832b99797d30600a0308