### PR TITLE
feat(joblauncher): introduce YAML job launcher with docs and tests

### DIFF
--- a/.github/workflows/common/action.yml
+++ b/.github/workflows/common/action.yml
@@ -40,6 +40,7 @@ runs:
     shell: bash
     run: |
       python -m pip install --upgrade pip
+      pip install -e '.[bzfs_joblauncher]'
       pip install --upgrade "coverage[toml]==7.*"
       if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
   - name: Install ssh + other dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -130,7 +130,7 @@ jobs:
     - name: Run pre-commit
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade "pre-commit==4.3"
+        pip install -e '.[dev,bzfs_joblauncher]'
         pre-commit run --all-files
     - name: Test with unittest
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Your context is your most valuable asset. Use it effectively.
   ```
   python3 -m venv venv                      # Create a Python virtual environment
   source venv/bin/activate                  # Activate it
-  pip install -e '.[dev]'                   # Install all development dependencies
+  pip install -e '.[dev,bzfs_joblauncher]'  # Install all development dependencies
   pre-commit install --install-hooks        # Ensure Linters and Formatters run on every commit
   ```
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ git clone https://github.com/whoschek/bzfs.git
 cd bzfs
 python3 -m venv venv                      # Create a Python virtual environment
 source venv/bin/activate                  # Activate it
-pip install -e '.[dev]'                   # Install all development dependencies
+pip install -e '.[dev,bzfs_joblauncher]'  # Install all development dependencies
 pre-commit install --install-hooks        # Ensure Linters and Formatters run on every commit
 ```
 

--- a/README_bzfs_joblauncher.md
+++ b/README_bzfs_joblauncher.md
@@ -1,0 +1,63 @@
+<!--
+ Copyright 2024 Wolfgang Hoschek AT mac DOT com
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.-->
+# YAML Job Launcher with bzfs_joblauncher
+- [Introduction](#Introduction)
+- [Man Page](#Man-Page)
+# Introduction
+<!-- DO NOT EDIT (This section was auto-generated from ArgumentParser help text as the source of "truth", via update_readme.sh) -->
+<!-- BEGIN DESCRIPTION SECTION -->
+Reads a YAML jobconfig and invokes bzfs_jobrunner with equivalent arguments.
+Unknown CLI arguments are forwarded to bzfs_jobrunner.
+
+<!-- END DESCRIPTION SECTION -->
+# Man Page
+<!-- BEGIN HELP OVERVIEW SECTION -->
+```
+usage: bzfs_joblauncher [-h] [--version] config
+```
+<!-- END HELP OVERVIEW SECTION -->
+<!-- BEGIN HELP DETAIL SECTION -->
+<div id="bzfs_joblauncher"></div>
+
+**bzfs_joblauncher** [-h] [--version] config
+
+# DESCRIPTION
+
+Reads a YAML jobconfig and invokes bzfs_jobrunner with equivalent arguments. Unknown CLI arguments
+are forwarded to bzfs_jobrunner.
+
+<div id="config"></div>
+
+**config**
+
+*  Path to YAML configuration file.
+
+
+
+<div id="--version"></div>
+
+**--version**
+
+*  show program's version number and exit
+
+## Install
+
+`bzfs_joblauncher` requires the optional `PyYAML` package.
+Install via:
+
+```
+pip install 'bzfs[bzfs_joblauncher]'
+```

--- a/README_bzfs_jobrunner.md
+++ b/README_bzfs_jobrunner.md
@@ -124,7 +124,7 @@ daemons but this is benign as these new processes immediately exit with a messag
 <!-- DO NOT EDIT (This section was auto-generated from ArgumentParser help text as the source of "truth", via update_readme.sh) -->
 <!-- BEGIN HELP OVERVIEW SECTION -->
 ```
-usage: bzfs_jobrunner [-h] [--create-src-snapshots] [--replicate []]
+usage: bzfs_jobrunner [-h] [--create-src-snapshots] [--replicate ]
                       [--prune-src-snapshots] [--prune-src-bookmarks]
                       [--prune-dst-snapshots]
                       [--monitor-src-snapshots]
@@ -151,7 +151,8 @@ usage: bzfs_jobrunner [-h] [--create-src-snapshots] [--replicate []]
                       [--daemon-prune-src-frequency STRING]
                       [--daemon-prune-dst-frequency STRING]
                       [--daemon-monitor-snapshots-frequency STRING]
-                      --root-dataset-pairs SRC_DATASET DST_DATASET [SRC_DATASET DST_DATASET ...]
+                      --root-dataset-pairs SRC_DATASET DST_DATASET
+                      [SRC_DATASET DST_DATASET ...]
 ```
 <!-- END HELP OVERVIEW SECTION -->
 

--- a/bash_completion_d/bzfs-shell-completion
+++ b/bash_completion_d/bzfs-shell-completion
@@ -70,3 +70,21 @@ _bzfs_jobrunner() {
 }
 
 complete -o default -o nospace -F _bzfs_jobrunner bzfs_jobrunner
+
+__opts_bzfs_joblauncher='--help --version -h'
+
+__choices_bzfs_joblauncher() { :; }
+
+_bzfs_joblauncher() {
+    local cur prev lst
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    lst=$(__choices_bzfs_joblauncher "$prev")
+    [[ -z $lst ]] && lst="$__opts_bzfs_joblauncher"
+    # shellcheck disable=SC2207
+    COMPREPLY=( $(compgen -W "$lst" -- "$cur") )
+    return 0
+}
+
+complete -o default -o nospace -F _bzfs_joblauncher bzfs_joblauncher

--- a/bash_completion_d/shell_completion_generator.py
+++ b/bash_completion_d/shell_completion_generator.py
@@ -23,7 +23,7 @@ import argparse
 import importlib
 from pathlib import Path
 
-programs = ("bzfs", "bzfs_jobrunner")
+programs = ("bzfs", "bzfs_jobrunner", "bzfs_joblauncher")
 
 
 def _version_line() -> str:

--- a/bzfs_main/bzfs_joblauncher.py
+++ b/bzfs_main/bzfs_joblauncher.py
@@ -1,0 +1,127 @@
+# Copyright 2024 Wolfgang Hoschek AT mac DOT com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reads a YAML jobconfig and runs ``bzfs_jobrunner`` with the same parameters."""
+
+from __future__ import annotations
+import argparse
+import subprocess
+import sys
+from typing import Any
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None
+
+from bzfs_main.argparse_cli import PROG_AUTHOR, __version__
+
+PROG_NAME = "bzfs_joblauncher"
+
+
+def argument_parser() -> argparse.ArgumentParser:
+    """Returns the CLI parser used by bzfs_joblauncher."""
+    parser = argparse.ArgumentParser(
+        prog=PROG_NAME,
+        allow_abbrev=False,
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=(
+            "Reads a YAML jobconfig and invokes bzfs_jobrunner with equivalent arguments.\n"
+            "Unknown CLI arguments are forwarded to bzfs_jobrunner."
+        ),
+    )
+    parser.add_argument("config", help="Path to YAML configuration file.")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__} by {PROG_AUTHOR}")
+    return parser
+
+
+def _build_cmd(config: dict[str, Any], unknown_args: list[str]) -> tuple[list[str], str]:
+    """Construct command line and stdin input for ``bzfs_jobrunner``."""
+    src_hosts = config.get("src_hosts", [])
+    cmd: list[str] = ["bzfs_jobrunner"]
+    if config.get("recursive"):
+        cmd.append("--recursive")
+    mapping_opts = {
+        "dst_hosts": "--dst-hosts",
+        "retain_dst_targets": "--retain-dst-targets",
+        "dst_root_datasets": "--dst-root-datasets",
+        "src_snapshot_plan": "--src-snapshot-plan",
+        "src_bookmark_plan": "--src-bookmark-plan",
+        "dst_snapshot_plan": "--dst-snapshot-plan",
+        "monitor_snapshot_plan": "--monitor-snapshot-plan",
+        "workers": "--workers",
+        "work_period_seconds": "--work-period-seconds",
+    }
+    for key, opt in mapping_opts.items():
+        if key in config:
+            cmd.append(f"{opt}={config[key]}")
+    if config.get("jitter"):
+        cmd.append("--jitter")
+    if (timeout := config.get("worker_timeout_seconds")) is not None:
+        cmd.append(f"--worker-timeout-seconds={timeout}")
+    cmd += config.get("extra_args", []) + unknown_args
+    if "root_dataset_pairs" in config:
+        pairs = [item for src, dst in config["root_dataset_pairs"] for item in (src, dst)]
+        cmd += ["--root-dataset-pairs"] + pairs
+    return cmd, f"{src_hosts}"
+
+
+def run(argv: list[str] | None = None) -> int:
+    """Parse CLI/YAML, run ``bzfs_jobrunner``.
+
+    Purpose: forward joblauncher configs to jobrunner.
+    Assumes optional PyYAML is present.
+    Design: load YAML, check for command flags, then spawn runner.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    parser = argument_parser()
+    args, unknown = parser.parse_known_args(argv)
+    if yaml is None:
+        print("ERROR: Install optional dependency 'PyYAML' via `pip install bzfs[bzfs_joblauncher]`.", file=sys.stderr)
+        return 5
+    try:
+        with open(args.config, encoding="utf-8") as fd:
+            config = yaml.safe_load(fd)
+    except yaml.YAMLError as exc:
+        print(f"ERROR: Failed to parse YAML config: {exc}", file=sys.stderr)
+        return 5
+    cmd, stdin_input = _build_cmd(config, unknown)
+    command_flags = {
+        "--create-src-snapshots",
+        "--replicate",
+        "--prune-src-snapshots",
+        "--prune-src-bookmarks",
+        "--prune-dst-snapshots",
+        "--monitor-src-snapshots",
+        "--monitor-dst-snapshots",
+    }
+    if not any(flag in cmd for flag in command_flags):
+        print(
+            "ERROR: Missing command. Usage: "
+            + sys.argv[0]
+            + " --create-src-snapshots|--replicate|--prune-src-snapshots|"
+            + "--prune-src-bookmarks|--prune-dst-snapshots|--monitor-src-snapshots|--monitor-dst-snapshots",
+            file=sys.stderr,
+        )
+        return 5
+    return subprocess.run(cmd, input=stdin_input, text=True).returncode
+
+
+def main(argv: list[str] | None = None) -> None:
+    """API for command line clients."""
+    sys.exit(run(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/bzfs_tests/bzfs_joblauncher_example.yaml
+++ b/bzfs_tests/bzfs_joblauncher_example.yaml
@@ -1,0 +1,88 @@
+# Example YAML jobconfig for bzfs_joblauncher.
+# Replicates two datasets from hostA to hostB with a simple retention policy.
+
+# List of (src_dataset, dst_dataset) pairs; each pair lists source then destination.
+root_dataset_pairs:
+  - [tank1/foo, tank1/foo]  # replicate to same name on hostB
+  - [tank1/bar, tank1/bar]  # replicate to same name on hostB
+
+# Include child datasets below each pair.
+recursive: true
+
+# Source hostnames; one per physical machine that takes snapshots.
+src_hosts:
+  - hostA
+
+# Map destination hostnames to logical target names used in snapshot names.
+dst_hosts:
+  hostB:
+    - offsite
+
+# Targets to retain on each destination host; usually the same as dst_hosts.
+retain_dst_targets:
+  hostB:
+    - offsite
+
+# Prefix prepended to each dataset on the destination host.
+dst_root_datasets:
+  hostB: ""  # empty string keeps original dataset names
+
+# Retention periods for snapshots to be used if pruning src, and when creating new snapshots on src.
+# For example, "daily": 31 specifies to retain all daily snapshots that were created less than 31 days ago, and
+# ensure that the latest 31 daily snapshots (per dataset) are retained regardless of creation time.
+# A zero or missing retention period indicates that no snapshots shall be retained (or even be created) for the given period.
+# Each target of each organization can have separate retention periods.
+# Uses snapshot names like 'prod_onsite_<timestamp>_daily', 'prod_onsite_<timestamp>_minutely', etc.:
+src_snapshot_plan:
+  prod:
+    offsite:
+      "5minutely": 10
+      hourly: 72
+      daily: 90
+
+# Retention periods for snapshots to be used if pruning dst. Has same format as --src-snapshot-plan:
+dst_snapshot_plan:
+  prod:
+    offsite:
+      "5minutely": 10
+      hourly: 72
+      daily: 90
+
+# Retention periods for bookmarks to be used if pruning src. Has same format as --src-snapshot-plan:
+src_bookmark_plan:
+  prod:
+    offsite:
+      "5minutely": 10
+      hourly: 72
+      daily: 90
+
+# Snapshot monitoring plan; alerts if snapshots fall behind schedule.
+monitor_snapshot_plan:
+  prod:
+    offsite:
+      "5minutely":
+        warning: "15 minutes"
+        critical: "30 minutes"
+      hourly:
+        warning: "3 hours"
+        critical: "6 hours"
+      daily:
+        warning: "2 days"
+        critical: "4 days"
+
+# Max worker jobs to run in parallel at any time; specified as a positive integer, or as a percentage of num CPU cores:
+workers: "100%"  # aka max_workers = 1.0 * num_cores
+
+# Reduce bandwidth spikes by evenly spreading the start of worker jobs over this much time; 0 disables this feature:
+work_period_seconds: 0
+
+# Randomize job start time and host order to avoid potential thundering herd problems in large distributed systems.
+# Randomizing job start time is only relevant if --work-period-seconds > 0.
+jitter: false  # don't randomize
+
+# If this much time has passed after a worker process has started executing, kill the straggling worker. Other workers remain
+# unaffected. A value of null disables this feature:
+worker_timeout_seconds: null
+
+# Extra command line arguments forwarded to bzfs_jobrunner.
+extra_args: []

--- a/bzfs_tests/test_all.py
+++ b/bzfs_tests/test_all.py
@@ -30,6 +30,7 @@ import bzfs_tests.test_filter
 import bzfs_tests.test_incremental_send_steps
 import bzfs_tests.test_integrations
 import bzfs_tests.test_interner
+import bzfs_tests.test_joblauncher
 import bzfs_tests.test_jobrunner
 import bzfs_tests.test_loggers
 import bzfs_tests.test_parallel_batch_cmd
@@ -64,6 +65,7 @@ def main() -> None:
         bzfs_tests.test_compare_snapshot_lists.suite(),
         bzfs_tests.test_snapshot_cache.suite(),
         bzfs_tests.test_jobrunner.suite(),
+        bzfs_tests.test_joblauncher.suite(),
     ]
     suite.addTests(suites)
     test_mode = bzfs_main.utils.getenv_any("test_mode", "")  # Consider toggling this when testing

--- a/bzfs_tests/test_joblauncher.py
+++ b/bzfs_tests/test_joblauncher.py
@@ -1,0 +1,191 @@
+# Copyright 2024 Wolfgang Hoschek AT mac DOT com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the ``bzfs_joblauncher`` CLI; Validates YAML parsing and command forwarding."""
+
+from __future__ import annotations
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - handled via skip
+    yaml = None
+
+from bzfs_tests.abstract_testcase import AbstractTestCase
+
+
+#############################################################################
+def suite() -> unittest.TestSuite:
+    if yaml is None:
+        return unittest.TestSuite()
+    test_cases = [TestJobLauncher]
+    return unittest.TestSuite(unittest.TestLoader().loadTestsFromTestCase(tc) for tc in test_cases)
+
+
+#############################################################################
+class TestJobLauncher(AbstractTestCase):
+
+    @patch("subprocess.run")
+    def test_launch(self, mock_run: MagicMock) -> None:
+        mock_run.return_value.returncode = 0
+        config = {
+            "root_dataset_pairs": [
+                ["tank1/foo", "tank1/foo"],
+                ["tank1/bar", "tank1/bar"],
+            ],
+            "recursive": True,
+            "src_hosts": ["nas"],
+            "dst_hosts": {"nas": [""]},
+            "retain_dst_targets": {"nas": [""]},
+            "dst_root_datasets": {"nas": ""},
+            "src_snapshot_plan": {"prod": {"onsite": {"daily": 1}}},
+            "dst_snapshot_plan": {"prod": {"onsite": {"daily": 1}}},
+            "src_bookmark_plan": {"prod": {"onsite": {"daily": 1}}},
+            "monitor_snapshot_plan": {"prod": {"onsite": {"daily": {"warning": "1 hour", "critical": "2 hours"}}}},
+            "workers": "100%",
+            "work_period_seconds": 0,
+            "jitter": False,
+            "worker_timeout_seconds": None,
+            "extra_args": ["--job-id=test"],
+            "env": {"TEST_ENV": "1"},
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            yaml.safe_dump(config, tmp)
+            path = tmp.name
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                from bzfs_main import bzfs_joblauncher
+
+                exit_code = bzfs_joblauncher.run([path, "--create-src-snapshots"])
+                self.assertEqual(0, exit_code)
+                mock_run.assert_called_once()
+                cmd = mock_run.call_args.args[0]
+                self.assertIn("--recursive", cmd)
+                self.assertIn("--dst-hosts={'nas': ['']}", cmd)
+                self.assertIn("--root-dataset-pairs", cmd)
+                self.assertIn("--job-id=test", cmd)
+                self.assertEqual("['nas']", mock_run.call_args.kwargs["input"])
+                self.assertNotIn("TEST_ENV", os.environ)
+        finally:
+            os.unlink(path)
+
+    def test_build_cmd_mapping(self) -> None:
+        config = {
+            "root_dataset_pairs": [["tank/a", "tank/a"], ["tank/b", "tank/b"]],
+            "recursive": True,
+            "src_hosts": ["s"],
+            "dst_hosts": {"d": ["t"]},
+            "retain_dst_targets": {"d": ["t"]},
+            "dst_root_datasets": {"d": "root"},
+            "src_snapshot_plan": {"prod": {"offsite": {"daily": 1}}},
+            "src_bookmark_plan": {"prod": {"offsite": {"daily": 1}}},
+            "dst_snapshot_plan": {"prod": {"offsite": {"daily": 1}}},
+            "monitor_snapshot_plan": {"prod": {"offsite": {"daily": {"warning": "1h", "critical": "2h"}}}},
+            "workers": "100%",
+            "work_period_seconds": 60,
+            "jitter": True,
+            "worker_timeout_seconds": 30,
+            "extra_args": ["--foo"],
+        }
+        from bzfs_main import bzfs_joblauncher
+
+        cmd, stdin_input = bzfs_joblauncher._build_cmd(config, ["--bar"])
+        expected_flags = [
+            "bzfs_jobrunner",
+            "--recursive",
+            "--dst-hosts={'d': ['t']}",
+            "--retain-dst-targets={'d': ['t']}",
+            "--dst-root-datasets={'d': 'root'}",
+            "--src-snapshot-plan={'prod': {'offsite': {'daily': 1}}}",
+            "--src-bookmark-plan={'prod': {'offsite': {'daily': 1}}}",
+            "--dst-snapshot-plan={'prod': {'offsite': {'daily': 1}}}",
+            "--monitor-snapshot-plan={'prod': {'offsite': {'daily': {'warning': '1h', 'critical': '2h'}}}}",
+            "--workers=100%",
+            "--work-period-seconds=60",
+            "--jitter",
+            "--worker-timeout-seconds=30",
+            "--foo",
+            "--bar",
+            "--root-dataset-pairs",
+            "tank/a",
+            "tank/a",
+            "tank/b",
+            "tank/b",
+        ]
+        self.assertEqual(expected_flags, cmd)
+        self.assertEqual("['s']", stdin_input)
+
+    def test_run_missing_command(self) -> None:
+        config = {"src_hosts": ["s"]}
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            yaml.safe_dump(config, tmp)
+            path = tmp.name
+        try:
+            from bzfs_main import bzfs_joblauncher
+
+            with patch("sys.stderr", new_callable=lambda: tempfile.TemporaryFile(mode="w+")) as fake_err:
+                exit_code = bzfs_joblauncher.run([path])
+                fake_err.seek(0)
+                err = fake_err.read()
+            self.assertEqual(5, exit_code)
+            self.assertIn("Missing command", err)
+        finally:
+            os.unlink(path)
+
+    @patch("subprocess.run")
+    def test_run_command_in_config(self, mock_run: MagicMock) -> None:
+        config = {"src_hosts": ["s"], "extra_args": ["--replicate"]}
+        mock_run.return_value.returncode = 0
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            yaml.safe_dump(config, tmp)
+            path = tmp.name
+        try:
+            from bzfs_main import bzfs_joblauncher
+
+            exit_code = bzfs_joblauncher.run([path])
+            self.assertEqual(0, exit_code)
+            mock_run.assert_called_once()
+            self.assertIn("--replicate", mock_run.call_args.args[0])
+        finally:
+            os.unlink(path)
+
+    def test_invalid_yaml(self) -> None:
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write("root_dataset_pairs: [ [tank1/foo, tank1/bar]")
+            path = tmp.name
+        try:
+            from bzfs_main import bzfs_joblauncher
+
+            with patch("sys.stderr", new_callable=lambda: tempfile.TemporaryFile(mode="w+")) as fake_err:
+                exit_code = bzfs_joblauncher.run([path, "--replicate"])
+                fake_err.seek(0)
+                err = fake_err.read()
+            self.assertEqual(5, exit_code)
+            self.assertIn("Failed to parse YAML", err)
+        finally:
+            os.unlink(path)
+
+    def test_missing_dependency(self) -> None:
+        from bzfs_main import bzfs_joblauncher
+
+        with patch.object(bzfs_joblauncher, "yaml", None):
+            with patch("sys.stderr", new_callable=lambda: tempfile.TemporaryFile(mode="w+")) as fake_err:
+                exit_code = bzfs_joblauncher.run(["config.yaml", "--replicate"])
+                fake_err.seek(0)
+                err = fake_err.read()
+        self.assertEqual(5, exit_code)
+        self.assertIn("Install optional dependency", err)

--- a/getting_started_bzfs_joblauncher.md
+++ b/getting_started_bzfs_joblauncher.md
@@ -1,0 +1,153 @@
+# Getting Started with bzfs_joblauncher
+
+This friendly guide shows how to set up `bzfs_joblauncher` so **hostA** regularly snapshots, replicates, and prunes the
+datasets `tank1/foo` and `tank1/bar` to **hostB**. Both hosts run OpenZFS and `bzfs` is installed on hostA.
+
+## 1. Install bzfs with joblauncher support
+
+```
+pip install 'bzfs[bzfs_joblauncher]'
+```
+
+## 2. Create `/etc/bzfs/bzfs_job_example.yaml`
+
+Save the following YAML as `/etc/bzfs/bzfs_job_example.yaml` on hostA. It captures the `prod/offsite` policy {
+"5minutely": 10, "hourly": 72, "daily": 90 } and runs every five minutes. List each source dataset followed by its
+destination; when the names are the same, repeat the dataset within the pair.
+
+```
+root_dataset_pairs:
+  - [tank1/foo, tank1/foo]  # replicate to same name on hostB
+  - [tank1/bar, tank1/bar]  # replicate to same name on hostB
+recursive: true  # include child datasets
+
+src_hosts:
+  - hostA  # source taking snapshots
+
+dst_hosts:
+  hostB:
+    - offsite  # logical target name embedded in snapshot names
+
+retain_dst_targets:
+  hostB:
+    - offsite  # keep offsite snapshots on hostB
+
+dst_root_datasets:
+  hostB: ''  # keep original dataset names on destination
+
+# Retention periods for snapshots to be used if pruning src, and when creating new snapshots on src.
+# For example, "daily": 31 specifies to retain all daily snapshots that were created less than 31 days ago, and
+# ensure that the latest 31 daily snapshots (per dataset) are retained regardless of creation time.
+# A zero or missing retention period indicates that no snapshots shall be retained (or even be created) for the given period.
+# Each target of each organization can have separate retention periods.
+# Uses snapshot names like 'prod_onsite_<timestamp>_daily', 'prod_onsite_<timestamp>_minutely', etc.:
+src_snapshot_plan:
+  prod:
+    offsite:
+      5minutely: 10
+      hourly: 72
+      daily: 90
+
+# Retention periods for snapshots to be used if pruning dst. Has same format as --src-snapshot-plan:
+dst_snapshot_plan:
+  prod:
+    offsite:
+      5minutely: 10
+      hourly: 72
+      daily: 90
+
+# Retention periods for bookmarks to be used if pruning src. Has same format as --src-snapshot-plan:
+src_bookmark_plan:
+  prod:
+    offsite:
+      5minutely: 10
+      hourly: 72
+      daily: 90
+
+monitor_snapshot_plan:
+  prod:
+    offsite:
+      5minutely:
+        warning: 15 minutes
+        critical: 30 minutes
+      hourly:
+        warning: 3 hours
+        critical: 6 hours
+      daily:
+        warning: 2 days
+        critical: 4 days
+
+# Max worker jobs to run in parallel at any time; specified as a positive integer, or as a percentage of num CPU cores:
+workers: "100%"        # aka max_workers = 1.0 * num_cores
+
+```
+
+## 3. Run the job once
+
+Start with a dry run to safely preview what would happen:
+
+```
+bzfs_joblauncher /etc/bzfs/bzfs_job_example.yaml --jobrunner-dryrun \
+  --create-src-snapshots --replicate \
+  --prune-src-snapshots --prune-src-bookmarks \
+  --prune-dst-snapshots --monitor-src-snapshots \
+  --monitor-dst-snapshots
+```
+
+`--jobrunner-dryrun` prints the planned operations without changing any ZFS state.
+
+If the output looks correct, remove `--jobrunner-dryrun` so the job runs but add `--dryrun` to keep `bzfs` from changing
+ZFS state:
+
+```
+bzfs_joblauncher /etc/bzfs/bzfs_job_example.yaml --dryrun \
+  --create-src-snapshots --replicate \
+  --prune-src-snapshots --prune-src-bookmarks \
+  --prune-dst-snapshots --monitor-src-snapshots \
+  --monitor-dst-snapshots
+```
+
+When you are satisfied with the simulated output, drop `--dryrun` to perform the real operations:
+
+```
+bzfs_joblauncher /etc/bzfs/bzfs_job_example.yaml \
+  --create-src-snapshots --replicate \
+  --prune-src-snapshots --prune-src-bookmarks \
+  --prune-dst-snapshots --monitor-src-snapshots \
+  --monitor-dst-snapshots
+```
+
+A `0` exit status means snapshots were taken, replicated, and pruned successfully.
+
+## 4. Schedule periodic runs
+
+Add a cron entry on hostA to repeat the job every five minutes:
+
+```
+*/5 * * * * bzfs_joblauncher /etc/bzfs/bzfs_job_example.yaml --create-src-snapshots --replicate \
+  --prune-src-snapshots --prune-src-bookmarks --prune-dst-snapshots \
+  --monitor-src-snapshots --monitor-dst-snapshots >>/var/log/bzfs_job.log 2>&1
+```
+
+## 5. Monitor health
+
+- **Snapshot schedule:** `monitor_snapshot_plan` above defines warning and critical thresholds. With
+  `--monitor-src-snapshots` and `--monitor-dst-snapshots`, the launcher exits non‑zero and logs a message if snapshots
+  fall behind on either host.
+- **Replication:** The same monitoring flags also confirm snapshots are arriving on hostB on time.
+- **Pruning:** The `--prune-*` flags remove outdated snapshots and bookmarks. Check `/var/log/bzfs_job.log` or run
+  `zfs list -t snapshot tank1/foo@* tank1/bar@*` on both hosts to confirm only 10 five‑minute, 72 hourly and 90 daily
+  snapshots remain.
+
+To run a quick health check at any time, add `-v` for verbose detail about which snapshots are late:
+
+```
+bzfs_joblauncher /etc/bzfs/bzfs_job_example.yaml -v --monitor-src-snapshots --monitor-dst-snapshots
+```
+
+Here `-v` increases log verbosity. A `0` exit code means the system is healthy; non‑zero indicates what fell behind.
+
+## 6. Enjoy
+
+You now have an automated replication setup that snapshots, replicates, prunes and monitors itself. Extend it by adding
+more dataset pairs, hosts, or `bzfs` options as your environment grows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ Changelog = "https://github.com/whoschek/bzfs/blob/main/CHANGELOG.md"
 Distribution = "https://pypi.org/project/bzfs"
 
 [project.optional-dependencies]
+bzfs_joblauncher = ["PyYAML==6.0.2"]
 dev = [  # for development only
   "argparse-manpage==4.7",          # see https://github.com/praiskup/argparse-manpage
   # "pandoc", # instead use this for pandoc >= 3.5: sudo apt-get -y install pandoc (Ubuntu) or brew install pandoc (OSX)
@@ -79,13 +80,14 @@ dev = [  # for development only
 # rm -rf venv
 # python3 -m venv venv                      # Create a Python virtual environment
 # source venv/bin/activate                  # Activate it
-# pip install -e '.[dev]'                   # Install all development dependencies
+# pip install -e '.[dev,bzfs_joblauncher]'  # Install all development dependencies
 # pre-commit install --install-hooks        # Ensure Linters and Formatters run on every commit
 # pip list --not-required
 
 [project.scripts]
 bzfs = "bzfs_main.bzfs:main"
 bzfs_jobrunner = "bzfs_main.bzfs_jobrunner:main"
+bzfs_joblauncher = "bzfs_main.bzfs_joblauncher:main"
 bzfs-test = "bzfs_tests.test_all:main"
 
 [tool.setuptools.packages.find]

--- a/update_readme.sh
+++ b/update_readme.sh
@@ -13,11 +13,12 @@ else
   python3 -m venv $tmp_venv
   # shellcheck disable=SC1091
   source $tmp_venv/bin/activate
-  pip install -e '.[dev]'
+  pip install -e '.[dev,bzfs_joblauncher]'
 fi
 
 python3 -m bzfs_docs.update_readme bzfs_main.bzfs README.md
 python3 -m bzfs_docs.update_readme bzfs_main.bzfs_jobrunner README_bzfs_jobrunner.md
+python3 -m bzfs_docs.update_readme bzfs_main.bzfs_joblauncher README_bzfs_joblauncher.md
 python3 -m bash_completion_d.shell_completion_generator > ./bash_completion_d/bzfs-shell-completion
 
 rm -rf $tmp_venv


### PR DESCRIPTION
**Note: This is just an experimental strawman idea to facilitate discussion, not intended to be merged.**

## Summary
- add `bzfs_joblauncher` CLI to run `bzfs_jobrunner` from YAML configs, validating parse errors and ensuring action flags are present
- provide documented example config, getting-started guide, and shell completion
- extend optional extras and unit tests so joblauncher is exercised only when `PyYAML` is installed

## Testing
- `bzfs_test_mode=unit ./test.sh`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b11ab92ac0832bb94f871d88b5f1e1